### PR TITLE
Improved results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work
 
 brzaguza-bin
 brzaguza.log
+brzaguza.*
 
 .vscode/*
 

--- a/go.mod
+++ b/go.mod
@@ -6,18 +6,16 @@ require (
 	github.com/alecthomas/kong v0.8.0
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
+	github.com/robertkrimen/otto v0.2.1
 	github.com/rs/zerolog v1.30.0
 	golang.org/x/time v0.3.0
 )
 
-require (
-	github.com/robertkrimen/otto v0.2.1 // indirect
-	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-)
+require gopkg.in/sourcemap.v1 v1.0.5 // indirect
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
-	github.com/PuerkitoBio/goquery v1.8.1 // indirect
+	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/antchfx/htmlquery v1.3.0 // indirect
 	github.com/antchfx/xmlquery v1.3.17 // indirect
@@ -31,7 +29,7 @@ require (
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/sourcegraph/conc v0.3.0
 	github.com/temoto/robotstxt v1.1.2 // indirect
-	golang.org/x/net v0.12.0 // indirect
+	golang.org/x/net v0.12.0
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/src/bucket/bucket.go
+++ b/src/bucket/bucket.go
@@ -50,7 +50,7 @@ func AddSEResult(seResult *structures.SEResult, seName string, relay *structures
 	}
 }
 
-func AddSEResultResponse(link string, response *colly.Response, relay *structures.Relay, seName string) {
+func SetResultResponse(link string, response *colly.Response, relay *structures.Relay, seName string) {
 	log.Trace().Msgf("%v: Got Response -> %v", seName, link)
 
 	relay.Mutex.Lock()

--- a/src/bucket/bucket.go
+++ b/src/bucket/bucket.go
@@ -3,38 +3,62 @@ package bucket
 import (
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
+	"github.com/tminaorg/brzaguza/src/config"
 	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/structures"
 )
 
-func SetResult(result *structures.Result, relay *structures.Relay, options *structures.Options, pagesCol *colly.Collector) {
-	log.Trace().Msgf("%v: Got Result -> %v: %v", result.SearchEngine, result.Title, result.URL)
+func AddSEResult(seResult *structures.SEResult, seName string, relay *structures.Relay, options *structures.Options, pagesCol *colly.Collector) {
+	log.Trace().Msgf("%v: Got Result -> %v: %v", seName, seResult.Title, seResult.URL)
 
-	relay.Mutex.Lock()
-	mapRes, exists := relay.ResultMap[result.URL]
+	relay.Mutex.RLock()
+	mapRes, exists := relay.ResultMap[seResult.URL]
+	relay.Mutex.RUnlock()
 
 	if !exists {
-		relay.ResultMap[result.URL] = result
-	} else if len(mapRes.Description) < len(result.Description) {
-		mapRes.Description = result.Description
-		//log.Trace().Msgf("%v: Extended Description -> %v: %v", result.SearchEngine, result.Title, result.URL)
+		searchEngines := make([]structures.SERank, config.NumberOfEngines)
+		searchEngines[0] = seResult.Rank
+		result := structures.Result{
+			URL:           seResult.URL,
+			Rank:          -1,
+			Title:         seResult.Title,
+			Description:   seResult.Description,
+			SearchEngines: searchEngines,
+			TimesReturned: 1,
+			Response:      nil,
+		}
+
+		if config.InsertDefaultRank {
+			result.Rank = rank.DefaultRank(seResult.Rank.Rank, seResult.Rank.Page, seResult.Rank.OnPageRank)
+		}
+
+		relay.Mutex.Lock()
+		relay.ResultMap[result.URL] = &result
+		relay.Mutex.Unlock()
+	} else {
+		relay.Mutex.Lock()
+		mapRes.SearchEngines[mapRes.TimesReturned] = seResult.Rank
+		mapRes.TimesReturned++
+		if len(mapRes.Description) < len(seResult.Description) {
+			mapRes.Description = seResult.Description
+		}
+		relay.Mutex.Unlock()
 	}
-	relay.Mutex.Unlock()
 
 	if !exists && options.VisitPages {
-		pagesCol.Visit(result.URL)
+		pagesCol.Visit(seResult.URL)
 	}
 }
 
-func SetResultResponse(link string, response *colly.Response, relay *structures.Relay, seName string) {
+func AddSEResultResponse(link string, response *colly.Response, relay *structures.Relay, seName string) {
 	log.Trace().Msgf("%v: Got Response -> %v", seName, link)
 
 	relay.Mutex.Lock()
 	mapRes, exists := relay.ResultMap[link]
 
 	if !exists {
-		log.Error().Msgf("URL not in map when adding response! Should not be possible. URL: %v", link)
 		relay.Mutex.Unlock()
+		log.Error().Msgf("URL not in map when adding response! Should not be possible. URL: %v", link)
 		return
 	}
 
@@ -44,4 +68,20 @@ func SetResultResponse(link string, response *colly.Response, relay *structures.
 	rankAddr := &(mapRes.Rank)
 	relay.Mutex.Unlock()
 	rank.SetRank(&resCopy, rankAddr, &(relay.Mutex)) //copy contains pointer to response
+}
+
+func MakeSEResult(urll string, title string, description string, searchEngineName string, seRank int, sePage int, seOnPageRank int) *structures.SEResult {
+	ser := structures.SERank{
+		SearchEngine: searchEngineName,
+		Rank:         seRank,
+		Page:         sePage,
+		OnPageRank:   seOnPageRank,
+	}
+	res := structures.SEResult{
+		URL:         urll,
+		Title:       title,
+		Description: description,
+		Rank:        ser,
+	}
+	return &res
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -2,3 +2,6 @@ package config
 
 const InsertDefaultRank bool = true
 const LogDumpLocation string = "logdump/"
+
+// update this when loading config
+var NumberOfEngines int = 10

--- a/src/engines/bing/bing.go
+++ b/src/engines/bing/bing.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -60,22 +58,9 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       -1,
-				SEPage:       page,
-				SEOnPageRank: pageRankCounter[page] + 1,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, -1, page, pageRankCounter[page]+1)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
-
-			bucket.SetResult(&res, relay, options, pagesCol)
 		} else {
 			log.Trace().Msgf("%v: Matched Result, but couldn't retrieve data.\nURL:%v\nTitle:%v\nDescription:%v", seName, linkText, titleText, descText)
 		}

--- a/src/engines/brave/brave.go
+++ b/src/engines/brave/brave.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gocolly/colly/v2"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -59,22 +57,9 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       -1,
-				SEPage:       page,
-				SEOnPageRank: pageRankCounter[page] + 1,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, -1, page, pageRankCounter[page]+1)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
-
-			bucket.SetResult(&res, relay, options, pagesCol)
 		}
 	})
 

--- a/src/engines/duckduckgo/duckduckgo.go
+++ b/src/engines/duckduckgo/duckduckgo.go
@@ -10,8 +10,6 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -86,21 +84,8 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 				linkText = utility.ParseURL(rawURL)
 			case 3:
 				if linkText != "" && linkText != "#" && titleText != "" {
-					res := structures.Result{
-						URL:          linkText,
-						Rank:         -1,
-						SERank:       rrank,
-						SEPage:       page,
-						SEOnPageRank: (i/4 + 1),
-						Title:        titleText,
-						Description:  descText,
-						SearchEngine: seName,
-					}
-					if config.InsertDefaultRank {
-						res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-					}
-
-					bucket.SetResult(&res, relay, options, pagesCol)
+					res := bucket.MakeSEResult(linkText, titleText, descText, seName, rrank, page, (i/4 + 1))
+					bucket.AddSEResult(res, seName, relay, options, pagesCol)
 				}
 			}
 		})

--- a/src/engines/etools/etools.go
+++ b/src/engines/etools/etools.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -74,21 +72,8 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			//var onPageRank int = e.Index // this should also work, but is a bit more volatile
 			var onPageRank int = (seRank-1)%resultsPerPage + 1
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       seRank,
-				SEPage:       page,
-				SEOnPageRank: onPageRank,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
-
-			bucket.SetResult(&res, relay, options, pagesCol)
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, seRank, page, onPageRank)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 		}
 	})
 

--- a/src/engines/google/google.go
+++ b/src/engines/google/google.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gocolly/colly/v2"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -52,22 +50,9 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       -1,
-				SEPage:       page,
-				SEOnPageRank: pageRankCounter[page] + 1,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, -1, page, pageRankCounter[page]+1)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
-
-			bucket.SetResult(&res, relay, options, pagesCol)
 		}
 	})
 

--- a/src/engines/mojeek/mojeek.go
+++ b/src/engines/mojeek/mojeek.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gocolly/colly/v2"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -53,22 +51,9 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       (page-1)*resPerPage + pageRankCounter[page] + 1,
-				SEPage:       page,
-				SEOnPageRank: pageRankCounter[page] + 1,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, (page-1)*resPerPage+pageRankCounter[page]+1, page, pageRankCounter[page]+1)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
-
-			bucket.SetResult(&res, relay, options, pagesCol)
 		}
 	})
 

--- a/src/engines/startpage/startpage.go
+++ b/src/engines/startpage/startpage.go
@@ -8,8 +8,6 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket"
-	"github.com/tminaorg/brzaguza/src/config"
-	"github.com/tminaorg/brzaguza/src/rank"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
 	"github.com/tminaorg/brzaguza/src/utility"
@@ -55,22 +53,9 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := structures.Result{
-				URL:          linkText,
-				Rank:         -1,
-				SERank:       -1,
-				SEPage:       page,
-				SEOnPageRank: pageRankCounter[page] + 1,
-				Title:        titleText,
-				Description:  descText,
-				SearchEngine: seName,
-			}
-			if config.InsertDefaultRank {
-				res.Rank = rank.DefaultRank(res.SERank, res.SEPage, res.SEOnPageRank)
-			}
+			res := bucket.MakeSEResult(linkText, titleText, descText, seName, -1, page, pageRankCounter[page]+1)
+			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
-
-			bucket.SetResult(&res, relay, options, pagesCol)
 		} else {
 			log.Trace().Msgf("%v: Matched Result, but couldn't retrieve data.\nURL:%v\nTitle:%v\nDescription:%v", seName, linkText, titleText, descText)
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -12,7 +12,14 @@ import (
 func printResults(results []structures.Result) {
 	fmt.Print("\n\tThe Search Results:\n\n")
 	for _, r := range results {
-		fmt.Printf("%v -----\n\t\"%v\"\n\t\"%v\"\n\t\"%v\"\n\t-%v\n", r.Rank, r.Title, r.URL, r.Description, r.SearchEngine)
+		fmt.Printf("%v -----\n\t\"%v\"\n\t\"%v\"\n\t\"%v\"\n\t-", r.Rank, r.Title, r.URL, r.Description)
+		for seInd := 0; seInd < r.TimesReturned; seInd++ {
+			fmt.Printf("%v", r.SearchEngines[seInd].SearchEngine)
+			if seInd != r.TimesReturned-1 {
+				fmt.Print(", ")
+			}
+		}
+		fmt.Printf("\n")
 	}
 }
 

--- a/src/rank/rank.go
+++ b/src/rank/rank.go
@@ -19,7 +19,7 @@ func SetRank(result *structures.Result, rankAddr *int, mutex *sync.RWMutex) {
 		log.Trace().Msgf("(This is ok) Request URL not same as result.URL \\/ %v | %v", reqUrl, result.URL)
 	}
 
-	rrank := result.SEPage*100 + result.SEOnPageRank
+	rrank := result.SearchEngines[0].Page*100 + result.SearchEngines[0].OnPageRank
 
 	mutex.Lock()
 	*rankAddr = rrank

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -47,7 +47,7 @@ func PerformSearch(query string, maxPages int, visitPages bool) []structures.Res
 	query = url.QueryEscape(query)
 
 	var worker conc.WaitGroup
-	var toSearch []Engine = []Engine{Swisscows}
+	var toSearch []Engine = []Engine{Swisscows, Mojeek, Etools}
 	runEngines(toSearch, query, &worker, &relay, &options)
 	worker.Wait()
 

--- a/src/sedefaults/sedefaults.go
+++ b/src/sedefaults/sedefaults.go
@@ -34,7 +34,7 @@ func PagesColError(seName string, pagesCol *colly.Collector) {
 func PagesColResponse(seName string, pagesCol *colly.Collector, relay *structures.Relay) {
 	pagesCol.OnResponse(func(r *colly.Response) {
 		urll := r.Ctx.Get("originalURL")
-		bucket.SetResultResponse(urll, r, relay, seName)
+		bucket.AddSEResultResponse(urll, r, relay, seName)
 	})
 }
 

--- a/src/sedefaults/sedefaults.go
+++ b/src/sedefaults/sedefaults.go
@@ -34,7 +34,7 @@ func PagesColError(seName string, pagesCol *colly.Collector) {
 func PagesColResponse(seName string, pagesCol *colly.Collector, relay *structures.Relay) {
 	pagesCol.OnResponse(func(r *colly.Response) {
 		urll := r.Ctx.Get("originalURL")
-		bucket.AddSEResultResponse(urll, r, relay, seName)
+		bucket.SetResultResponse(urll, r, relay, seName)
 	})
 }
 

--- a/src/structures/structures.go
+++ b/src/structures/structures.go
@@ -29,17 +29,33 @@ type Options struct {
 	VisitPages    bool
 }
 
-// SE* variables are 1-indexed
-type Result struct {
-	URL          string
-	Rank         int
-	SERank       int
-	SEPage       int
-	SEOnPageRank int
-	Title        string
-	Description  string
+// variables are 1-indexed
+// Information about what Rank a result was on some Search Engine
+type SERank struct {
 	SearchEngine string
-	Response     *colly.Response
+	Rank         int
+	Page         int
+	OnPageRank   int
+}
+
+// The info a Search Engine returned about some Result
+type SEResult struct {
+	URL         string
+	Title       string
+	Description string
+	Rank        SERank
+}
+
+// Everything about some Result, calculated and compiled from multiple search engines
+// The URL is the primary key
+type Result struct {
+	URL           string
+	Rank          int
+	Title         string
+	Description   string
+	SearchEngines []SERank
+	TimesReturned int
+	Response      *colly.Response
 }
 
 /*


### PR DESCRIPTION
+ Restructured search results structures
```go
// variables are 1-indexed
// Information about what Rank a result was on some Search Engine
type SERank struct {
	SearchEngine string
	Rank         int
	Page         int
	OnPageRank   int
}

// The info a Search Engine returned about some Result
type SEResult struct {
	URL         string
	Title       string
	Description string
	Rank        SERank
}

// Everything about some Result, calculated and compiled from multiple search engines
// The URL is the primary key
type Result struct {
	URL           string
	Rank          int
	Title         string
	Description   string
	SearchEngines []SERank
	TimesReturned int
	Response      *colly.Response
}
```

+ Pulled structure creation into bucket.go
![image](https://github.com/tminaorg/brzaguza/assets/124312252/efd76acc-8f84-4fca-bb7e-5965c685b14d)
+ Refactored search engines to accomodate
+ Updated and renamed bucket.go functions