### PR TITLE
Rate limiting

### DIFF
--- a/src/engines/bing/bing.go
+++ b/src/engines/bing/bing.go
@@ -28,7 +28,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/brave/brave.go
+++ b/src/engines/brave/brave.go
@@ -27,7 +27,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/duckduckgo/duckduckgo.go
+++ b/src/engines/duckduckgo/duckduckgo.go
@@ -29,7 +29,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/etools/etools.go
+++ b/src/engines/etools/etools.go
@@ -33,7 +33,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/google/google.go
+++ b/src/engines/google/google.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket"
 	"github.com/tminaorg/brzaguza/src/sedefaults"
 	"github.com/tminaorg/brzaguza/src/structures"
@@ -21,12 +20,12 @@ const seURL string = "https://www.google.com/search?q="
 const resPerPage int = 10
 
 // This should be in SESettings
-var limitRule colly.LimitRule = colly.LimitRule{
-	// DomainReqexp: strings.ReplaceAll(SEDomain, ".", "\\.")
-	DomainGlob:  SEDomain, //note - this will not work for all engines
+var timings structures.Timings = structures.Timings{
+	Timeout:     10 * time.Second, // the default in colly
+	PageTimeout: 5 * time.Second,
 	Delay:       100 * time.Millisecond,
 	RandomDelay: 50 * time.Millisecond,
-	Parallelism: 2, //two requests will be sent to the server, each 100 + [0,50) milliseconds
+	Parallelism: 2, //two requests will be sent to the server, 100 + [0,50) milliseconds apart from the next two
 }
 
 func Search(ctx context.Context, query string, relay *structures.Relay, options *structures.Options) error {
@@ -38,7 +37,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options, &limitRule)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, &timings)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)
@@ -65,14 +64,6 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 			bucket.AddSEResult(res, seName, relay, options, pagesCol)
 			pageRankCounter[page]++
 		}
-	})
-
-	col.OnResponse(func(r *colly.Response) {
-		log.Info().Msg("Got response")
-	})
-
-	col.OnRequest(func(r *colly.Request) {
-		log.Info().Msg("On request")
 	})
 
 	colCtx := colly.NewContext()

--- a/src/engines/mojeek/mojeek.go
+++ b/src/engines/mojeek/mojeek.go
@@ -27,7 +27,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/qwant/qwant.go
+++ b/src/engines/qwant/qwant.go
@@ -59,7 +59,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/startpage/startpage.go
+++ b/src/engines/startpage/startpage.go
@@ -30,7 +30,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/engines/swisscows/swisscows.go
+++ b/src/engines/swisscows/swisscows.go
@@ -48,7 +48,7 @@ func Search(ctx context.Context, query string, relay *structures.Relay, options 
 	var pagesCol *colly.Collector
 	var retError error
 
-	sedefaults.InitializeCollectors(&col, &pagesCol, options)
+	sedefaults.InitializeCollectors(&col, &pagesCol, options, nil)
 
 	sedefaults.PagesColRequest(seName, pagesCol, &ctx, &retError)
 	sedefaults.PagesColError(seName, pagesCol)

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -47,7 +47,7 @@ func PerformSearch(query string, maxPages int, visitPages bool) []structures.Res
 	query = url.QueryEscape(query)
 
 	var worker conc.WaitGroup
-	var toSearch []Engine = []Engine{Swisscows, Mojeek, Etools}
+	var toSearch []Engine = []Engine{Google}
 	runEngines(toSearch, query, &worker, &relay, &options)
 	worker.Wait()
 

--- a/src/sedefaults/sedefaults.go
+++ b/src/sedefaults/sedefaults.go
@@ -78,7 +78,7 @@ func FunctionPrepare(seName string, options *structures.Options, ctx *context.Co
 	return nil
 }
 
-func InitializeCollectors(colPtr **colly.Collector, pagesColPtr **colly.Collector, options *structures.Options, limitRule *colly.LimitRule) {
+func InitializeCollectors(colPtr **colly.Collector, pagesColPtr **colly.Collector, options *structures.Options, timings *structures.Timings) {
 	if options.MaxPages == 1 {
 		*colPtr = colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent)) // so there is no thread creation overhead
 	} else {
@@ -86,7 +86,20 @@ func InitializeCollectors(colPtr **colly.Collector, pagesColPtr **colly.Collecto
 	}
 	*pagesColPtr = colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent), colly.Async())
 
-	if limitRule != nil {
+	if timings != nil {
+		var limitRule *colly.LimitRule = &colly.LimitRule{
+			DomainGlob:  "*",
+			Delay:       timings.Delay,
+			RandomDelay: timings.RandomDelay,
+			Parallelism: timings.Parallelism,
+		}
+
 		(*colPtr).Limit(limitRule)
+		if timings.Timeout != 0 {
+			(*colPtr).SetRequestTimeout(timings.Timeout)
+		}
+		if timings.PageTimeout != 0 {
+			(*pagesColPtr).SetRequestTimeout(timings.PageTimeout)
+		}
 	}
 }

--- a/src/sedefaults/sedefaults.go
+++ b/src/sedefaults/sedefaults.go
@@ -78,11 +78,15 @@ func FunctionPrepare(seName string, options *structures.Options, ctx *context.Co
 	return nil
 }
 
-func InitializeCollectors(colPtr **colly.Collector, pagesColPtr **colly.Collector, options *structures.Options) {
+func InitializeCollectors(colPtr **colly.Collector, pagesColPtr **colly.Collector, options *structures.Options, limitRule *colly.LimitRule) {
 	if options.MaxPages == 1 {
 		*colPtr = colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent)) // so there is no thread creation overhead
 	} else {
 		*colPtr = colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent), colly.Async())
 	}
 	*pagesColPtr = colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent), colly.Async())
+
+	if limitRule != nil {
+		(*colPtr).Limit(limitRule)
+	}
 }

--- a/src/structures/structures.go
+++ b/src/structures/structures.go
@@ -2,9 +2,20 @@ package structures
 
 import (
 	"sync"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 )
+
+// Delegates Timeout, PageTimeout to colly.Collector.SetRequestTimeout(); Note: See https://github.com/gocolly/colly/issues/644
+// Delegates Delay, RandomDelay, Parallelism to colly.Collector.Limit()
+type Timings struct {
+	Timeout     time.Duration
+	PageTimeout time.Duration
+	Delay       time.Duration
+	RandomDelay time.Duration
+	Parallelism int
+}
 
 type Relay struct {
 	ResultMap         map[string]*Result


### PR DESCRIPTION
Also added a working example to `google.go`:
```go
// This should be in SESettings
var timings structures.Timings = structures.Timings{
	Timeout:     10 * time.Second, // the default in colly
	PageTimeout: 5 * time.Second,
	Delay:       100 * time.Millisecond,
	RandomDelay: 50 * time.Millisecond,
	Parallelism: 2, //two requests will be sent to the server, 100 + [0,50) milliseconds apart from the next two
}
```
