### PR TITLE
Unit tests, enumer, config path bug, Brave & Google DOM

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,8 +46,7 @@ jobs:
       # go:generate
       - name: Generate go code from go:generate comments
         run: |
-          go install github.com/dmarkham/enumer@latest
-          go generate ./...
+          make install
 
       # build
       - name: Snapshot on non-tag
@@ -67,6 +66,11 @@ jobs:
           args: release --clean --config goreleaser/release.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # go:test
+      - name: Test units
+        run: |
+          make test
 
       # cache
       - uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,5 @@ install:
 	go install github.com/dmarkham/enumer@latest
 	go generate ./...
 	go mod tidy
+test:
+	go test ./... -count=1

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,5 @@ install:
 	go get ./...
 	go install github.com/dmarkham/enumer@latest
 	go generate ./...
-	go mod tidy
 test:
 	go test ./... -count=1

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -25,10 +25,10 @@ func (c *Config) Load(path string) {
 	k.Load(structs.Provider(c, "koanf"), nil)
 
 	// Load YAML config
-	yamlPath := path + ".yaml"
+	yamlPath := path + "/brzaguza.yaml"
 	if _, err := os.Stat(yamlPath); err != nil {
 		log.Trace().Msgf("no yaml config present at path: %v, looking for .yml", yamlPath)
-		yamlPath = path + ".yml"
+		yamlPath = path + "/brzaguza.yml"
 		if _, errr := os.Stat(yamlPath); errr != nil {
 			log.Trace().Msgf("no yaml config present at path: %v", yamlPath)
 		} else if errr := k.Load(file.Provider(yamlPath), yaml.Parser()); errr != nil {

--- a/src/engines/bing/bing_test.go
+++ b/src/engines/bing/bing_test.go
@@ -1,0 +1,50 @@
+package bing_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Bing.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/bing/bing_test.go
+++ b/src/engines/bing/bing_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Bing
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Bing.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/brave/brave_test.go
+++ b/src/engines/brave/brave_test.go
@@ -1,0 +1,50 @@
+package brave_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Brave.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/brave/brave_test.go
+++ b/src/engines/brave/brave_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Brave
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Brave.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/brave/options.go
+++ b/src/engines/brave/options.go
@@ -10,10 +10,10 @@ var Info engines.Info = engines.Info{
 }
 
 var dompaths engines.DOMPaths = engines.DOMPaths{
-	Result:      "div#results > div[class*=\"snippet fdb\"][data-type=\"web\"]",
-	Link:        "a.result-header",
-	Title:       "a.result-header > span.snippet-title",
-	Description: "div.snippet-content > p.snippet-description",
+	Result:      "div.snippet",
+	Link:        "a",
+	Title:       "div.title",
+	Description: "div.snippet-description",
 }
 
 var Support engines.SupportedSettings = engines.SupportedSettings{}

--- a/src/engines/duckduckgo/duckduckgo_test.go
+++ b/src/engines/duckduckgo/duckduckgo_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.DuckDuckGo
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.DuckDuckGo.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/duckduckgo/duckduckgo_test.go
+++ b/src/engines/duckduckgo/duckduckgo_test.go
@@ -1,0 +1,50 @@
+package duckduckgo_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.DuckDuckGo.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/etools/etools_test.go
+++ b/src/engines/etools/etools_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Etools
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Etools.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/etools/etools_test.go
+++ b/src/engines/etools/etools_test.go
@@ -1,0 +1,50 @@
+package etools_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Etools.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/google/google_test.go
+++ b/src/engines/google/google_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Google
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Google.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/google/google_test.go
+++ b/src/engines/google/google_test.go
@@ -1,0 +1,50 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Google.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/google/options.go
+++ b/src/engines/google/options.go
@@ -27,8 +27,8 @@ var timings config.Timings = config.Timings{
 var dompaths engines.DOMPaths = engines.DOMPaths{
 	Result:      "div.g",
 	Link:        "a",
-	Title:       "div > div > div > a > h3",
-	Description: "div > div > div > div:first-child > span:first-child",
+	Title:       "a > h3",
+	Description: "div > span",
 }
 
 var Support engines.SupportedSettings = engines.SupportedSettings{}

--- a/src/engines/mojeek/mojeek_test.go
+++ b/src/engines/mojeek/mojeek_test.go
@@ -1,0 +1,50 @@
+package mojeek_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Mojeek.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/mojeek/mojeek_test.go
+++ b/src/engines/mojeek/mojeek_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Mojeek
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Mojeek.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/name.go
+++ b/src/engines/name.go
@@ -4,7 +4,7 @@ import "strings"
 
 type Name uint8
 
-//go:generate enumer -type=Name
+//go:generate enumer -type=Name -json -text -yaml -sql
 const (
 	Undefined Name = iota
 	Bing

--- a/src/engines/presearch/presearch_test.go
+++ b/src/engines/presearch/presearch_test.go
@@ -1,0 +1,50 @@
+package presearch_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Presearch.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/presearch/presearch_test.go
+++ b/src/engines/presearch/presearch_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Presearch
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Presearch.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/qwant/qwant_test.go
+++ b/src/engines/qwant/qwant_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Qwant
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Qwant.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/qwant/qwant_test.go
+++ b/src/engines/qwant/qwant_test.go
@@ -1,0 +1,50 @@
+package qwant_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Qwant.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/startpage/startpage_test.go
+++ b/src/engines/startpage/startpage_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Startpage
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Startpage.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/startpage/startpage_test.go
+++ b/src/engines/startpage/startpage_test.go
@@ -1,0 +1,50 @@
+package startpage_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Startpage.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/swisscows/swisscows_test.go
+++ b/src/engines/swisscows/swisscows_test.go
@@ -1,0 +1,50 @@
+package swisscows_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Swisscows.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/swisscows/swisscows_test.go
+++ b/src/engines/swisscows/swisscows_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Swisscows
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Swisscows.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/yahoo/yahoo_test.go
+++ b/src/engines/yahoo/yahoo_test.go
@@ -1,0 +1,50 @@
+package yahoo_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Yahoo.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/yahoo/yahoo_test.go
+++ b/src/engines/yahoo/yahoo_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Yahoo
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Yahoo.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/engines/yep/yep_test.go
+++ b/src/engines/yep/yep_test.go
@@ -1,0 +1,50 @@
+package yep_test
+
+import (
+	"testing"
+
+	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
+	"github.com/tminaorg/brzaguza/src/search"
+)
+
+type TestCase struct {
+	query   string
+	options engines.Options
+}
+
+func TestSearch(t *testing.T) {
+	// testing config
+	conf := config.Config{
+		Engines: map[string]config.Engine{
+			engines.Yep.ToLower(): {
+				Enabled: true,
+			},
+		},
+	}
+
+	// enabled engines names
+	for name, engine := range conf.Engines {
+		if engine.Enabled {
+			if engineName, err := engines.NameString(name); err == nil {
+				config.EnabledEngines = append(config.EnabledEngines, engineName)
+			}
+		}
+	}
+
+	// test cases
+	testCases := [...]TestCase{{
+		query: "wikipedia",
+		options: engines.Options{
+			MaxPages:   1,
+			VisitPages: false,
+		},
+	}}
+
+	// running tests
+	for _, tc := range testCases {
+		if results := search.PerformSearch(tc.query, tc.options, &conf); len(results) == 0 {
+			t.Errorf("Got no results for %v", tc.query)
+		}
+	}
+}

--- a/src/engines/yep/yep_test.go
+++ b/src/engines/yep/yep_test.go
@@ -14,23 +14,19 @@ type TestCase struct {
 }
 
 func TestSearch(t *testing.T) {
+	engineName := engines.Yep
+
 	// testing config
 	conf := config.Config{
 		Engines: map[string]config.Engine{
-			engines.Yep.ToLower(): {
+			engineName.ToLower(): {
 				Enabled: true,
 			},
 		},
 	}
 
 	// enabled engines names
-	for name, engine := range conf.Engines {
-		if engine.Enabled {
-			if engineName, err := engines.NameString(name); err == nil {
-				config.EnabledEngines = append(config.EnabledEngines, engineName)
-			}
-		}
-	}
+	config.EnabledEngines = append(config.EnabledEngines, engineName)
 
 	// test cases
 	testCases := [...]TestCase{{

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/bucket/result"
 	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
 	"github.com/tminaorg/brzaguza/src/logger"
 	"github.com/tminaorg/brzaguza/src/router"
 	"github.com/tminaorg/brzaguza/src/search"
@@ -44,8 +45,13 @@ func main() {
 			Str("visit", fmt.Sprintf("%v", cli.Visit)).
 			Msg("Started searching")
 
+		options := engines.Options{
+			MaxPages:   cli.MaxPages,
+			VisitPages: cli.Visit,
+		}
+
 		start := time.Now()
-		results := search.PerformSearch(cli.Query, cli.MaxPages, cli.Visit, config)
+		results := search.PerformSearch(cli.Query, options, config)
 		duration := time.Since(start)
 		if !cli.Silent {
 			printResults(results)

--- a/src/router/search.go
+++ b/src/router/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
 	"github.com/tminaorg/brzaguza/src/config"
+	"github.com/tminaorg/brzaguza/src/engines"
 	"github.com/tminaorg/brzaguza/src/search"
 )
 
@@ -25,13 +26,18 @@ func Search(config *config.Config) {
 		}
 
 		deepSearch := c.DefaultQuery("deep", "false")
-		visit := false
+		visitPages := false
 		if deepSearch != "false" {
 			log.Trace().Msgf("doing a deep search because deep is: %v", deepSearch)
-			visit = true
+			visitPages = true
 		}
 
-		results := search.PerformSearch(query, maxPages, visit, config)
+		options := engines.Options{
+			MaxPages:   maxPages,
+			VisitPages: visitPages,
+		}
+
+		results := search.PerformSearch(query, options, config)
 
 		if resultsJson, err := json.Marshal(results); err != nil {
 			log.Error().Err(err).Msg("failed marshalling results")
@@ -52,13 +58,18 @@ func Search(config *config.Config) {
 		}
 
 		deepSearch := c.DefaultPostForm("deep", "false")
-		visit := false
+		visitPages := false
 		if deepSearch != "false" {
 			log.Trace().Msgf("doing a deep search because deep is: %v", deepSearch)
-			visit = true
+			visitPages = true
 		}
 
-		results := search.PerformSearch(query, maxPages, visit, config)
+		options := engines.Options{
+			MaxPages:   maxPages,
+			VisitPages: visitPages,
+		}
+
+		results := search.PerformSearch(query, options, config)
 
 		if resultsJson, err := json.Marshal(results); err != nil {
 			log.Error().Err(err).Msg("failed marshalling results")

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -26,15 +26,10 @@ import (
 	"github.com/tminaorg/brzaguza/src/rank"
 )
 
-func PerformSearch(query string, maxPages int, visitPages bool, config *config.Config) []result.Result {
+func PerformSearch(query string, options engines.Options, config *config.Config) []result.Result {
 	relay := bucket.Relay{
 		ResultMap:         make(map[string]*result.Result),
 		EngineDoneChannel: make(chan bool),
-	}
-
-	options := engines.Options{
-		MaxPages:   maxPages,
-		VisitPages: visitPages,
 	}
 
 	query = url.QueryEscape(query)


### PR DESCRIPTION
1. Added unit tests for all search engines
2. Added `-json -text -yaml -sql` to `enumer`, which is needed for correct translation from enum to string (json unmarshal, future redis cache)
3. Moved `cli.maxPages` and `cli.visit` to `engines.Options` struct. This affects `search.PerformSearch` function.
4. Added `make test` command to run go unit tests without cache
5. Switch to `make install` and add `make test` to CI
6. **Fixed BUG when loading config, forgotten `/brzaguza` in the path.**

**CRITICAL**
1. Fixed Brave HTML DOM
2. FIxed Google HTML DOM