### PR TITLE
improved ranking

### DIFF
--- a/src/bucket/bucket.go
+++ b/src/bucket/bucket.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tminaorg/brzaguza/src/bucket/result"
 	"github.com/tminaorg/brzaguza/src/config"
 	"github.com/tminaorg/brzaguza/src/engines"
-	"github.com/tminaorg/brzaguza/src/rank"
 )
 
 type Relay struct {
@@ -34,10 +33,6 @@ func AddSEResult(seResult *engines.RetrievedResult, seName engines.Name, relay *
 			EngineRanks:   engineRanks,
 			TimesReturned: 1,
 			Response:      nil,
-		}
-
-		if config.InsertDefaultRank {
-			result.Rank = rank.DefaultRank(seResult.Rank.Rank, seResult.Rank.Page, seResult.Rank.OnPageRank)
 		}
 
 		relay.Mutex.Lock()
@@ -83,17 +78,13 @@ func SetResultResponse(link string, response *colly.Response, relay *Relay, seNa
 	}
 
 	mapRes.Response = response
-
-	resCopy := *mapRes
-	rankAddr := &(mapRes.Rank)
 	relay.Mutex.Unlock()
-	rank.SetRank(&resCopy, rankAddr, &(relay.Mutex)) //copy contains pointer to response
 }
 
-func MakeSEResult(urll string, title string, description string, searchEngineName engines.Name, seRank int, sePage int, seOnPageRank int) *engines.RetrievedResult {
+func MakeSEResult(urll string, title string, description string, searchEngineName engines.Name, sePage int, seOnPageRank int) *engines.RetrievedResult {
 	ser := engines.RetrievedRank{
 		SearchEngine: searchEngineName,
-		Rank:         seRank,
+		Rank:         -1,
 		Page:         sePage,
 		OnPageRank:   seOnPageRank,
 	}

--- a/src/cli.go
+++ b/src/cli.go
@@ -55,7 +55,7 @@ func setupCli() {
 		kong.Vars{
 			"version":      fmt.Sprintf("%v (%v@%v)", Version, GitCommit, Timestamp),
 			"config_path":  ".",
-			"log_path":     ".",
+			"log_path":     "./log",
 			"query_string": "banana death",
 		},
 	)

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -62,5 +62,4 @@ func (c *Config) Load(path string) {
 	}
 }
 
-const InsertDefaultRank bool = true       // this should be moved to config
 const LogDumpLocation string = "logdump/" // this should be moved to config

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -14,8 +14,12 @@ import (
 )
 
 var EnabledEngines []engines.Name = make([]engines.Name, 0)
+var LogDumpLocation string = "dump/"
 
-func (c *Config) Load(path string) {
+func (c *Config) Load(path string, logPath string) {
+	// Load vars
+	loadVars(logPath)
+
 	// Use "." as the key path delimiter. This can be "/" or any character.
 	k := koanf.New(".")
 
@@ -62,4 +66,6 @@ func (c *Config) Load(path string) {
 	}
 }
 
-const LogDumpLocation string = "logdump/" // this should be moved to config
+func loadVars(logPath string) {
+	LogDumpLocation = logPath + "/" + LogDumpLocation
+}

--- a/src/engines/bing/bing.go
+++ b/src/engines/bing/bing.go
@@ -56,7 +56,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, -1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		} else {

--- a/src/engines/brave/brave.go
+++ b/src/engines/brave/brave.go
@@ -52,7 +52,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, -1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		}

--- a/src/engines/duckduckgo/duckduckgo.go
+++ b/src/engines/duckduckgo/duckduckgo.go
@@ -62,7 +62,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 				linkText = parse.ParseURL(rawURL)
 			case 3:
 				if linkText != "" && linkText != "#" && titleText != "" {
-					res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, rrank, page, (i/4 + 1))
+					res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, (i/4 + 1))
 					bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 				}
 			}

--- a/src/engines/google/google.go
+++ b/src/engines/google/google.go
@@ -45,7 +45,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, -1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		}

--- a/src/engines/mojeek/mojeek.go
+++ b/src/engines/mojeek/mojeek.go
@@ -46,7 +46,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, (page-1)*Info.ResultsPerPage+pageRankCounter[page]+1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		}

--- a/src/engines/presearch/presearch.go
+++ b/src/engines/presearch/presearch.go
@@ -68,7 +68,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 				goodTitle := parse.ParseTextWithHTML(result.Title)
 				goodDesc := parse.ParseTextWithHTML(result.Desc)
 
-				res := bucket.MakeSEResult(goodURL, goodTitle, goodDesc, Info.Name, -1, page, counter)
+				res := bucket.MakeSEResult(goodURL, goodTitle, goodDesc, Info.Name, page, counter)
 				bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 				counter += 1
 			}

--- a/src/engines/qwant/qwant.go
+++ b/src/engines/qwant/qwant.go
@@ -49,7 +49,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		}
 
 		mainline := parsedResponse.Data.Res.Items.Mainline
-		counter := 0
+		counter := 1
 		for _, group := range mainline {
 			if group.Type != "web" {
 				continue
@@ -57,7 +57,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			for _, result := range group.Items {
 				goodURL := parse.ParseURL(result.URL)
 
-				res := bucket.MakeSEResult(goodURL, result.Title, result.Description, Info.Name, (page-1)*Info.ResultsPerPage+counter, page, counter%Info.ResultsPerPage+1)
+				res := bucket.MakeSEResult(goodURL, result.Title, result.Description, Info.Name, page, counter)
 				bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 				counter += 1
 			}

--- a/src/engines/startpage/startpage.go
+++ b/src/engines/startpage/startpage.go
@@ -46,7 +46,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, -1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		} else {

--- a/src/engines/swisscows/swisscows.go
+++ b/src/engines/swisscows/swisscows.go
@@ -74,13 +74,13 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			log.Error().Err(err).Msgf("%v: Failed body unmarshall to json:\n%v", Info.Name, string(r.Body))
 		}
 
-		counter := 0
+		counter := 1
 		for _, result := range parsedResponse.Items {
 			goodURL := parse.ParseURL(result.URL)
 			title := parse.ParseTextWithHTML(result.Title)
 			desc := parse.ParseTextWithHTML(result.Desc)
 
-			res := bucket.MakeSEResult(goodURL, title, desc, Info.Name, -1, page, counter%Info.ResultsPerPage+1)
+			res := bucket.MakeSEResult(goodURL, title, desc, Info.Name, page, counter)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			counter += 1
 		}

--- a/src/engines/yahoo/yahoo.go
+++ b/src/engines/yahoo/yahoo.go
@@ -48,7 +48,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			var pageStr string = e.Request.Ctx.Get("page")
 			page, _ := strconv.Atoi(pageStr)
 
-			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, -1, page, pageRankCounter[page]+1)
+			res := bucket.MakeSEResult(linkText, titleText, descText, Info.Name, page, pageRankCounter[page]+1)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			pageRankCounter[page]++
 		}

--- a/src/engines/yep/yep.go
+++ b/src/engines/yep/yep.go
@@ -34,7 +34,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 	col.OnResponse(func(r *colly.Response) {
 		content := parseJSON(r.Body)
 
-		counter := 0
+		counter := 1
 		for _, result := range content.Results {
 			if result.TType != "Organic" {
 				continue
@@ -44,7 +44,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			goodTitle := parse.ParseTextWithHTML(result.Title)
 			goodDescription := parse.ParseTextWithHTML(result.Snippet)
 
-			res := bucket.MakeSEResult(goodURL, goodTitle, goodDescription, Info.Name, counter, counter/Info.ResultsPerPage+1, counter%Info.ResultsPerPage+1)
+			res := bucket.MakeSEResult(goodURL, goodTitle, goodDescription, Info.Name, 1, counter)
 			bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 			counter += 1
 		}

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -18,7 +18,7 @@ func DateString() string {
 func Setup(path string, verbosity int) {
 	// Generate logfile name
 	datetime := DateString()
-	filepath := fmt.Sprintf("%v/log/brzaguza_%v.log", path, datetime)
+	filepath := fmt.Sprintf("%v/brzaguza_%v.log", path, datetime)
 
 	// Setup logger
 	logger := log.Output(io.MultiWriter(zerolog.ConsoleWriter{

--- a/src/main.go
+++ b/src/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// load config file
 	config := config.New()
-	config.Load(cli.Config)
+	config.Load(cli.Config, cli.Log)
 
 	if cli.Cli {
 		log.Info().

--- a/src/rank/byrank.go
+++ b/src/rank/byrank.go
@@ -1,9 +1,28 @@
 package rank
 
-import "github.com/tminaorg/brzaguza/src/bucket/result"
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/tminaorg/brzaguza/src/bucket/result"
+)
 
 type ByRank []result.Result
 
 func (r ByRank) Len() int           { return len(r) }
 func (r ByRank) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r ByRank) Less(i, j int) bool { return r[i].Rank < r[j].Rank }
+
+type ByRetrievedRank []RankFiller
+
+func (r ByRetrievedRank) Len() int      { return len(r) }
+func (r ByRetrievedRank) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r ByRetrievedRank) Less(i, j int) bool {
+	if r[i].RetRank.Page != r[j].RetRank.Page {
+		return r[i].RetRank.Page < r[j].RetRank.Page
+	}
+	if r[i].RetRank.OnPageRank != r[j].RetRank.OnPageRank {
+		return r[i].RetRank.OnPageRank < r[j].RetRank.OnPageRank
+	}
+
+	log.Error().Msgf("failed at ranking: %v, %v", r[i], r[j])
+	return true
+}

--- a/src/rank/rank.go
+++ b/src/rank/rank.go
@@ -36,7 +36,7 @@ type RankFiller struct {
 }
 
 func FillRetrievedRank(results []result.Result) {
-	engResults := make([][]RankFiller, 100) //TODO. need as many elements as there are implemented engines. the value used for len in searcher/buildOneRun
+	engResults := make([][]RankFiller, len(engines.NameValues()))
 	for arrind, res := range results {
 		for rrind, er := range res.EngineRanks {
 			rf := RankFiller{

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -33,7 +33,7 @@ func PerformSearch(query string, options engines.Options, config *config.Config)
 	results := rank.Rank(relay.ResultMap)
 	log.Debug().Msgf("Finished ranking in %v", time.Since(rankTiming).Milliseconds())
 
-	log.Debug().Msg("Search Done!")
+	log.Debug().Msg("Search done!")
 
 	return results
 }

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -3,7 +3,7 @@ package search
 import (
 	"context"
 	"net/url"
-	"sort"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/sourcegraph/conc"
@@ -21,19 +21,19 @@ func PerformSearch(query string, options engines.Options, config *config.Config)
 
 	query = url.QueryEscape(query)
 
+	resTiming := time.Now()
+	log.Debug().Msg("Waiting for results from engines...")
 	var worker conc.WaitGroup
 	runEngines(config.Engines, query, &worker, &relay, options)
-	log.Debug().Msg("Waiting for results from engines...")
 	worker.Wait()
+	log.Debug().Msgf("Got results in %v", time.Since(resTiming).Milliseconds())
 
-	results := make([]result.Result, 0, len(relay.ResultMap))
-	for _, res := range relay.ResultMap {
-		results = append(results, *res)
-	}
+	rankTiming := time.Now()
+	log.Debug().Msg("Ranking...")
+	results := rank.Rank(relay.ResultMap)
+	log.Debug().Msgf("Finished ranking in %v", time.Since(rankTiming).Milliseconds())
 
-	sort.Sort(rank.ByRank(results))
-
-	log.Debug().Msg("All processing done!")
+	log.Debug().Msg("Search Done!")
 
 	return results
 }


### PR DESCRIPTION
Improved the ranking system.
Now ranking is done after all results are retrieved.
`RetrievedRank.Rank` cannot be set anymore, only `.Page` and `.OnPageRank`. `.Rank` is calculated after all results are collected. This standardizes the info we have for results, making our ranking easier. Now the ranking will be a bit slower though, since it is not run while the retreival happens, but after. It could be parallelized so it is done for each engines results separately, though this is not the case right now.
