### PR TITLE
chore: Gitignore for logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ test.go
 src/engines/*/site/*
 !src/engines/_engines_test
 
-logdump/*.html
-log/*.log
+log/
 database/
 profiling/
 


### PR DESCRIPTION
Because logdump locations now resides within `log/` dir