### PR TITLE
fix: Increased fly limits

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -20,8 +20,8 @@ primary_region = "cdg"
   processes = ["app"]
   [http_service.concurrency]
     type = "requests"
-    hard_limit = 5
-    soft_limit = 1
+    hard_limit = 10
+    soft_limit = 5
 
   [[http_service.checks]]
     interval = "30s"


### PR DESCRIPTION
With soft limit set to 1 and two clients trying to connect to the same region (for both the closest one) ends up moving one client to the next closest region (if there aren't 2 instances in that same region). This PR allows 5 parallel clients to send requests to the same instance before being moved to other instances.