### PR TITLE
fix: url parsing

### DIFF
--- a/src/config/defaults.go
+++ b/src/config/defaults.go
@@ -92,7 +92,7 @@ func NewSettings() map[engines.Name]Settings {
 			Shortcut: "ets",
 		},
 		engines.GOOGLE: {
-			Shortcut: "go",
+			Shortcut: "g",
 		},
 		engines.MOJEEK: {
 			Shortcut: "mjk",

--- a/src/search/parse/parse.go
+++ b/src/search/parse/parse.go
@@ -22,11 +22,6 @@ func ParseURL(rawURL string) string {
 func parseURL(rawURL string) (string, error) {
 	// rawURL may be empty string, function should return empty string then.
 	rawURL = strings.TrimSpace(rawURL)
-	rawURL, unescErr := url.QueryUnescape(rawURL) // if the url was part of a telemetry link, this will help.
-	if unescErr != nil {
-		return "", fmt.Errorf("parse.parseURL(): failed url.QueryUnescape() on url(%v). error: %w", rawURL, unescErr)
-	}
-
 	parsedURL, parseErr := url.Parse(rawURL)
 	if parseErr != nil {
 		return "", fmt.Errorf("parse.parseURL(): failed url.Parse() on url(%v). error: %w", rawURL, parseErr)
@@ -36,6 +31,7 @@ func parseURL(rawURL string) (string, error) {
 	if len(urlString) != 0 && len(parsedURL.Path) == 0 { // https://example.org -> https://example.org/
 		urlString += "/"
 	}
+
 	return urlString, nil
 }
 

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -26,7 +26,7 @@ func PerformSearch(query string, options engines.Options, conf *config.Config) [
 	timings, toRun := procBang(&query, &options, conf)
 
 	query = url.QueryEscape(query)
-	log.Debug().Msg(query)
+	log.Debug().Msgf("Searching: %v", query)
 
 	resTimer := time.Now()
 	log.Debug().Msg("Waiting for results from engines...")

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -58,6 +58,7 @@ func runEngines(engs []engines.Name, timings config.Timings, settings map[engine
 		eng := engs[i] // dont change for to `for _, eng := range engs {`, eng retains the same address throughout the whole loop
 		worker.Go(func() {
 			// if an error can be handled inside, it wont be returned
+			// runs the Search function in the engine package
 			err := engineStarter[eng](context.Background(), query, relay, options, settings[eng], timings)
 			if err != nil {
 				log.Error().Err(err).Msgf("search.runEngines(): error while searching %v", eng)

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -96,7 +96,6 @@ func procSpecificEngine(query string, options *engines.Options, conf *config.Con
 	sp := strings.SplitN(query, " ", 2)
 	bangWord := sp[0][1:]
 	for key, val := range conf.Settings {
-		log.Info().Msgf("q: %v, lookat: %v", bangWord, val.Shortcut)
 		if strings.EqualFold(bangWord, val.Shortcut) || strings.EqualFold(bangWord, key.String()) {
 			return true, key
 		}

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -94,9 +94,10 @@ func procSpecificEngine(query string, options *engines.Options, conf *config.Con
 		return false, engines.UNDEFINED
 	}
 	sp := strings.SplitN(query, " ", 2)
-	specE := sp[0][1:]
+	bangWord := sp[0][1:]
 	for key, val := range conf.Settings {
-		if val.Shortcut == specE {
+		log.Info().Msgf("q: %v, lookat: %v", bangWord, val.Shortcut)
+		if strings.EqualFold(bangWord, val.Shortcut) || strings.EqualFold(bangWord, key.String()) {
 			return true, key
 		}
 	}


### PR DESCRIPTION
+ `g++ documentation`-like queries now work because QueryUnescape is removed, any telemetry shenanigans will be handled in the specific Search function of the engine if/when they prop up (fixes #168)
+ added a comment for clarity
+ make the search bang for specific engines more flexible (case insensitive, now includes full engine name)
+ changed the shortcut for google from `go` to `g`
+ renamed `specE` variable to `bangWord` for clarity
