### PR TITLE
fix: review and cleanup code relating to bing image search

### DIFF
--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -157,7 +157,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			return
 		}
 
-		thmbW, err := strconv.Atoi(thmbHS)
+		thmbW, err := strconv.Atoi(thmbWS)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -51,7 +51,8 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		if err := json.Unmarshal([]byte(metadataS), &jsonMetadata); err != nil {
 			log.Error().
 				Err(err).
-				Msg("bingimages.Search() -> onHTML: failed to unmarshal metadata")
+				Str("jsonMetadata", metadataS).
+				Msgf("bingimages.Search() -> onHTML: failed to unmarshal metadata")
 			return
 		}
 

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -196,6 +196,14 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		pageRankCounter[page]++
 	})
 
+	col.OnResponse(func(r *colly.Response) {
+		if len(r.Body) == 0 {
+			log.Trace().
+				Str("engine", Info.Name.String()).
+				Msgf("Got empty response, probably too many requests")
+		}
+	})
+
 	localeParam := getLocale(&options)
 
 	colCtx := colly.NewContext()

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -42,7 +42,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		var jsonMetadata JsonMetadata
 		metadataS, metadataExists := dom.Find(dompaths.Metadata.Path).Attr(dompaths.Metadata.Attr)
 		if !metadataExists {
-			log.Trace().
+			log.Error().
 				Str("engine", Info.Name.String()).
 				Msg("Matched result, but couldn't retrieve data")
 			return

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -63,7 +63,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 				Str("url", jsonMetadata.PageURL).
 				Str("original", jsonMetadata.ImageURL).
 				Str("thumbnail", jsonMetadata.ThumbnailURL).
-				Msg("bingimages.Search() -> onHTML: Couldn't find image URL")
+				Msg("bingimages.Search() -> onHTML: Couldn't find image, thumbnail, or page URL")
 			return
 		}
 

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -69,7 +69,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 
 		titleText := strings.TrimSpace(dom.Find(dompaths.Title).Text())
 		if titleText == "" {
-			// could also use the json data ("t" field)
+			// could also use the json data ("t" field), it seems to include weird/erroneous characters though (particularly '\ue000' and '\ue001')
 			log.Error().
 				Str("engine", Info.Name.String()).
 				Str("jsonMetadata", metadataS).

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -55,13 +55,13 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 			return
 		}
 
-		if jsonMetadata.Purl == "" || jsonMetadata.Murl == "" || jsonMetadata.Turl == "" {
+		if jsonMetadata.ImageURL == "" || jsonMetadata.PageURL == "" || jsonMetadata.ThumbnailURL == "" {
 			log.Error().
 				Str("engine", Info.Name.String()).
 				Str("jsonMetadata", metadataS).
-				Str("url", jsonMetadata.Purl).
-				Str("original", jsonMetadata.Murl).
-				Str("thumbnail", jsonMetadata.Turl).
+				Str("url", jsonMetadata.PageURL).
+				Str("original", jsonMetadata.ImageURL).
+				Str("thumbnail", jsonMetadata.ThumbnailURL).
 				Msg("bingimages.Search() -> onHTML: Couldn't find image URL")
 			return
 		}
@@ -180,17 +180,17 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		page := _sedefaults.PageFromContext(e.Request.Ctx, Info.Name)
 
 		original := result.Image{
-			URL:    jsonMetadata.Murl,
+			URL:    jsonMetadata.ImageURL,
 			Height: uint(imgH),
 			Width:  uint(imgW),
 		}
 		thumbnail := result.Image{
-			URL:    jsonMetadata.Turl,
+			URL:    jsonMetadata.ThumbnailURL,
 			Height: uint(thmbH),
 			Width:  uint(thmbW),
 		}
 
-		res := bucket.MakeSEImageResult(jsonMetadata.Purl, titleText, jsonMetadata.Desc, source, original, thumbnail, Info.Name, page, pageRankCounter[page]+1)
+		res := bucket.MakeSEImageResult(jsonMetadata.PageURL, titleText, jsonMetadata.Desc, source, original, thumbnail, Info.Name, page, pageRankCounter[page]+1)
 		bucket.AddSEResult(res, Info.Name, relay, &options, pagesCol)
 		pageRankCounter[page]++
 	})

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -80,8 +80,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 		// this returns "2000 x 1500 · jpeg"
 		imgFormatS := strings.TrimSpace(dom.Find(dompaths.ImgFormatStr).Text())
 		if imgFormatS == "" {
-			// this happens when bingimages returns video instead of image
-			log.Trace().
+			log.Error().
 				Str("engine", Info.Name.String()).
 				Str("jsonMetadata", metadataS).
 				Str("title", titleText).

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -69,6 +69,7 @@ func Search(ctx context.Context, query string, relay *bucket.Relay, options engi
 
 		titleText := strings.TrimSpace(dom.Find(dompaths.Title).Text())
 		if titleText == "" {
+			// could also use the json data ("t" field)
 			log.Error().
 				Str("engine", Info.Name.String()).
 				Str("jsonMetadata", metadataS).

--- a/src/search/engines/bingimages/dom.go
+++ b/src/search/engines/bingimages/dom.go
@@ -21,7 +21,8 @@ type bingImagesDomPaths struct {
 }
 
 var dompaths = bingImagesDomPaths{
-	Result: "ul.dgControl_list > li",
+	// aria-live is also a possible attribute for not()
+	Result: "ul.dgControl_list > li[data-idx] > div.iuscp:not([vrhatt])",
 	Metadata: metadataDomPaths{
 		Path: "a.iusc",
 		Attr: "m",

--- a/src/search/engines/bingimages/json.go
+++ b/src/search/engines/bingimages/json.go
@@ -1,8 +1,8 @@
 package bingimages
 
 type JsonMetadata struct {
-	Purl string `json:"purl"`
-	Turl string `json:"turl"`
-	Murl string `json:"murl"`
-	Desc string `json:"desc"`
+	PageURL      string `json:"purl"`
+	ThumbnailURL string `json:"turl"`
+	ImageURL     string `json:"murl"`
+	Desc         string `json:"desc"`
 }


### PR DESCRIPTION
- [x] Make Bingimages match only images and not videos
- [x] Switch Trace to Error in imgformat since videos aren't matched
- [x] Clean up JSON field names
- [x] Log JSON data if unmarshal fails
- [x] More descriptive errors if image/json/thumbnail url is missing