### PR TITLE
fix: handle empty query correctly

### DIFF
--- a/src/search/category/category.go
+++ b/src/search/category/category.go
@@ -22,7 +22,7 @@ var FromString = map[string]Name{
 
 // returns category
 func FromQuery(query string) Name {
-	if query[0] != '!' {
+	if query == "" || query[0] != '!' {
 		return ""
 	}
 	cat := strings.SplitN(query, " ", 2)[0][1:]

--- a/src/search/perform.go
+++ b/src/search/perform.go
@@ -20,10 +20,21 @@ import (
 type EngineSearch func(context.Context, string, *bucket.Relay, engines.Options, config.Settings, config.Timings) error
 
 func PerformSearch(query string, options engines.Options, conf *config.Config) []result.Result {
+	if query == "" {
+		log.Trace().Msg("Empty search query.")
+		return []result.Result{}
+	}
+
 	searchTimer := time.Now()
 
 	query, timings, enginesToRun := procBang(query, &options, conf)
 	query = url.QueryEscape(query)
+
+	// check again after the bang is taken out
+	if query == "" {
+		log.Trace().Msg("Empty search query (with bang present).")
+		return []result.Result{}
+	}
 
 	log.Debug().
 		Str("queryAnon", anonymize.String(query)).

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -36,6 +36,8 @@ func Search(query string, options engines.Options, conf *config.Config, db cache
 			Str("queryAnon", anonymize.String(query)).
 			Str("queryHash", anonymize.HashToSHA256B64(query)).
 			Msg("Nothing found in cache, doing a clean search")
+
+		// the main line
 		results = PerformSearch(query, options, conf)
 	}
 


### PR DESCRIPTION
+ PerformSearch now doesnt send requests if query is empty
+ query processing functions (mostly utils.go) now handle an empty query correctly
+ added some comments for clarity