### PR TITLE
fix(cors,healthcheck): multiple urls for CORS with wildcard support and string response for healthcheck

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = "cdg"
 
 [env]
   HEARCHCO_SERVER_CACHE_TYPE = "redis"
-  HEARCHCO_SERVER_FRONTENDURL = "*"
+  HEARCHCO_SERVER_FRONTENDURLS = "http://localhost:5173,https://*.hearch.co,https://*.hearchco-frontend.pages.dev"
 
 [http_service]
   internal_port = 3030

--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = "cdg"
 
 [env]
   HEARCHCO_SERVER_CACHE_TYPE = "redis"
-  HEARCHCO_SERVER_FRONTENDURLS = "http://localhost:5173,https://*.hearch.co,https://*.hearchco-frontend.pages.dev"
+  HEARCHCO_SERVER_FRONTENDURLS = "http://localhost:5173,https://*hearch.co,https://*hearchco-frontend.pages.dev"
 
 [http_service]
   internal_port = 3030

--- a/hearchco_example.yaml
+++ b/hearchco_example.yaml
@@ -1,7 +1,7 @@
 server:
   # beware this bug with trailing * for wildcard CORS
   # https://github.com/gin-contrib/cors/pull/106
-  frontendurls: http://localhost:5173,https://*.hearch.co,https://*.hearchco-frontend.pages.dev
+  frontendurls: http://localhost:5173,https://*hearch.co,https://*hearchco-frontend.pages.dev
   cache:
     type: none
 # categories:

--- a/hearchco_example.yaml
+++ b/hearchco_example.yaml
@@ -1,5 +1,7 @@
 server:
-  frontendurl: http://localhost:5173
+  # beware this bug with trailing * for wildcard CORS
+  # https://github.com/gin-contrib/cors/pull/106
+  frontendurls: http://localhost:5173,https://*.hearch.co,https://*.hearchco-frontend.pages.dev
   cache:
     type: none
 # categories:

--- a/src/config/defaults.go
+++ b/src/config/defaults.go
@@ -144,8 +144,8 @@ func NewScience() []engines.Name {
 func New() *Config {
 	return &Config{
 		Server: Server{
-			Port:        3030,
-			FrontendUrl: "http://localhost:8000",
+			Port:         3030,
+			FrontendUrls: []string{"http://localhost:5173"},
 			Cache: Cache{
 				Type: "badger",
 				TTL: TTL{

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -23,8 +23,8 @@ var LogDumpLocation string = "dump/"
 func (c *Config) fromReader(rc *ReaderConfig) {
 	nc := Config{
 		Server: Server{
-			Port:        rc.Server.Port,
-			FrontendUrl: rc.Server.FrontendUrl,
+			Port:         rc.Server.Port,
+			FrontendUrls: strings.Split(rc.Server.FrontendUrls, ","),
 			Cache: Cache{
 				Type: rc.Server.Cache.Type,
 				TTL: TTL{
@@ -85,8 +85,8 @@ func (c *Config) fromReader(rc *ReaderConfig) {
 func (c *Config) getReader() ReaderConfig {
 	rc := ReaderConfig{
 		Server: ReaderServer{
-			Port:        c.Server.Port,
-			FrontendUrl: c.Server.FrontendUrl,
+			Port:         c.Server.Port,
+			FrontendUrls: strings.Join(c.Server.FrontendUrls, ","),
 			Cache: ReaderCache{
 				Type: c.Server.Cache.Type,
 				TTL: ReaderTTL{

--- a/src/config/structs.go
+++ b/src/config/structs.go
@@ -86,6 +86,8 @@ type ReaderServer struct {
 	// port on which the API server listens
 	Port int `koanf:"port"`
 	// urls used for CORS, comma separated and converted into slice
+	// WARN: beware this bug with trailing * for wildcard CORS
+	// https://github.com/gin-contrib/cors/pull/106
 	FrontendUrls string `koanf:"frontendurls"`
 	// cache settings
 	Cache ReaderCache `koanf:"cache"`

--- a/src/config/structs.go
+++ b/src/config/structs.go
@@ -85,15 +85,15 @@ type Cache struct {
 type ReaderServer struct {
 	// port on which the API server listens
 	Port int `koanf:"port"`
-	// frontend url needed for CORS
-	FrontendUrl string `koanf:"frontendurl"`
+	// urls used for CORS, comma separated and converted into slice
+	FrontendUrls string `koanf:"frontendurls"`
 	// cache settings
 	Cache ReaderCache `koanf:"cache"`
 }
 type Server struct {
-	Port        int `koanf:"port"`
-	FrontendUrl string
-	Cache       Cache
+	Port         int
+	FrontendUrls []string
+	Cache        Cache
 }
 
 // ReaderEngine is format in which the config is read from the config file

--- a/src/router/healthcheck.go
+++ b/src/router/healthcheck.go
@@ -7,7 +7,5 @@ import (
 )
 
 func HealthCheck(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"message": "API is up and working fine",
-	})
+	c.String(http.StatusOK, "OK")
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -42,10 +42,11 @@ func New(config *config.Config, verbosity int8, lgr zerolog.Logger) (*RouterWrap
 
 	// add CORS middleware
 	log.Debug().
-		Str("url", config.Server.FrontendUrl).
+		Strs("url", config.Server.FrontendUrls).
 		Msg("Using CORS")
 	gengine.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{config.Server.FrontendUrl},
+		AllowOrigins:     config.Server.FrontendUrls,
+		AllowWildcard:    true,
 		AllowMethods:     []string{"HEAD", "GET", "POST"},
 		AllowHeaders:     []string{"Origin", "X-Requested-With", "Content-Length", "Content-Type", "Accept"},
 		AllowCredentials: false,

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -38,7 +38,7 @@ func New(config *config.Config, verbosity int8, lgr zerolog.Logger) (*RouterWrap
 			Str("path", c.Request.URL.Path).
 			Str("ip", c.ClientIP()).
 			Logger()
-	}), logger.WithDefaultFieldsDisabled(), logger.WithLatency(), logger.WithSkipPath([]string{"/health", "/healthz"})))
+	}), logger.WithDefaultFieldsDisabled(), logger.WithLatency(), logger.WithSkipPath([]string{"/healthz"})))
 
 	// add CORS middleware
 	log.Debug().
@@ -81,8 +81,7 @@ func (rw *RouterWrapper) runWithContext(ctx context.Context) error {
 }
 
 func (rw *RouterWrapper) Start(ctx context.Context, db cache.DB, serveProfiler bool) error {
-	// health(z)
-	rw.router.GET("/health", HealthCheck)
+	// healthz
 	rw.router.GET("/healthz", HealthCheck)
 
 	// search


### PR DESCRIPTION
This allows local frontend, `hearch.co` and all it's subdomains as well as `hearchco-frontend.pages.dev` and all it's subdomains to use production backend (CORS).

1) Frontend devs don't have to run backend anymore
2) Future custom subdomains of hearch.co will work (staging, preview, dev...)
3) Cloudflare Pages preview builds can use the backend

Before, this was only possible with `*` for CORS.