### PR TITLE
fix(result): correctly shortening results to 2500 chars, added unit test

### DIFF
--- a/src/router/search.go
+++ b/src/router/search.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hearchco/hearchco/src/search"
 	"github.com/hearchco/hearchco/src/search/category"
 	"github.com/hearchco/hearchco/src/search/engines"
-	"github.com/hearchco/hearchco/src/search/result"
 )
 
 func Search(c *gin.Context, db cache.DB, ttlConf config.TTL, settings map[engines.Name]config.Settings, categories map[category.Name]config.Category) error {
@@ -150,7 +149,7 @@ func Search(c *gin.Context, db cache.DB, ttlConf config.TTL, settings map[engine
 	}
 
 	results, foundInDB := search.Search(query, options, db, settings, categories)
-	c.JSON(http.StatusOK, result.Shorten(results))
+	c.JSON(http.StatusOK, results)
 
 	search.CacheAndUpdateResults(query, options, db, ttlConf, settings, categories, results, foundInDB)
 	return nil

--- a/src/search/result/shorten.go
+++ b/src/search/result/shorten.go
@@ -1,6 +1,6 @@
 package result
 
-func firstNchars(str string, n int) string {
+func FirstNchars(str string, n int) string {
 	v := []rune(str)
 	if n >= len(v) {
 		return str
@@ -8,14 +8,19 @@ func firstNchars(str string, n int) string {
 	return string(v[:n])
 }
 
-func Shorten(results []Result) []Result {
-	resultsShort := make([]Result, len(results))
-	copy(resultsShort, results)
-	for _, result := range resultsShort {
-		if len(result.Description) >= 400 {
-			descShort := firstNchars(result.Description, 397)
+// modifies the passed slice of results,
+// changes the description of the results to be at most N characters long
+func Shorten(results []Result, n int) {
+	if n-3 < 0 {
+		return
+	}
+
+	// can't use _, result := range short because we need to modify the elements in slice
+	for i := range results {
+		result := &results[i]
+		if len(result.Description) > n {
+			descShort := FirstNchars(result.Description, n-3)
 			result.Description = descShort + "..."
 		}
 	}
-	return resultsShort
 }

--- a/src/search/result/shorten.go
+++ b/src/search/result/shorten.go
@@ -2,7 +2,7 @@ package result
 
 func FirstNchars(str string, n int) string {
 	v := []rune(str)
-	if n >= len(v) {
+	if n < 0 || n >= len(v) {
 		return str
 	}
 	return string(v[:n])
@@ -11,16 +11,19 @@ func FirstNchars(str string, n int) string {
 // modifies the passed slice of results,
 // changes the description of the results to be at most N characters long
 func Shorten(results []Result, n int) {
-	if n-3 < 0 {
+	suffix := "..."
+	if n < 0 {
 		return
+	} else if n-len(suffix) <= 0 {
+		suffix = "" // no room for suffix
 	}
 
 	// can't use _, result := range short because we need to modify the elements in slice
 	for i := range results {
 		result := &results[i]
 		if len(result.Description) > n {
-			descShort := FirstNchars(result.Description, n-3)
-			result.Description = descShort + "..."
+			descShort := FirstNchars(result.Description, n-len(suffix))
+			result.Description = descShort + suffix
 		}
 	}
 }

--- a/src/search/result/shorten_test.go
+++ b/src/search/result/shorten_test.go
@@ -1,0 +1,65 @@
+package result_test
+
+import (
+	"testing"
+
+	"github.com/hearchco/hearchco/src/search/result"
+)
+
+type testPair struct {
+	orig     string
+	expected string
+}
+
+func TestFirstNchars(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		{"", ""},
+		{"banana death", "banana dea"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lorem ipsu"},
+		{"Ćao 🐹 hrčko!!", "Ćao 🐹 hrčk"},
+	}
+
+	for _, test := range tests {
+		v := result.FirstNchars(test.orig, 10)
+		if v != test.expected {
+			t.Errorf("FirstNChars(%q) = %q, want %q", test.orig, v, test.expected)
+		}
+	}
+}
+
+func TestShorten(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 304 characters
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit."},
+		// 400 characters -> 400 characters
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it."},
+		// 402 characters -> 400 characters with ... as the last 3 characters
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and p..."},
+		// 445 characters -> 400 characters with ... as the last 3 characters
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa ..."},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 400)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}

--- a/src/search/result/shorten_test.go
+++ b/src/search/result/shorten_test.go
@@ -11,7 +11,58 @@ type testPair struct {
 	expected string
 }
 
-func TestFirstNchars(t *testing.T) {
+func TestFirstNcharsNegative(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		{"", ""},
+		{"banana death", "banana death"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},
+		{"Ćao 🐹 hrčko!!", "Ćao 🐹 hrčko!!"},
+	}
+
+	for _, test := range tests {
+		v := result.FirstNchars(test.orig, -1)
+		if v != test.expected {
+			t.Errorf("FirstNChars(%q) = %q, want %q", test.orig, v, test.expected)
+		}
+	}
+}
+
+func TestFirstNcharsZero(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		{"", ""},
+		{"banana death", ""},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", ""},
+		{"Ćao 🐹 hrčko!!", ""},
+	}
+
+	for _, test := range tests {
+		v := result.FirstNchars(test.orig, 0)
+		if v != test.expected {
+			t.Errorf("FirstNChars(%q) = %q, want %q", test.orig, v, test.expected)
+		}
+	}
+}
+
+func TestFirstNchars1(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		{"", ""},
+		{"banana death", "b"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "L"},
+		{"Ćao 🐹 hrčko!!", "Ć"},
+	}
+
+	for _, test := range tests {
+		v := result.FirstNchars(test.orig, 1)
+		if v != test.expected {
+			t.Errorf("FirstNChars(%q) = %q, want %q", test.orig, v, test.expected)
+		}
+	}
+}
+
+func TestFirstNchars10(t *testing.T) {
 	// original string, expected string
 	tests := []testPair{
 		{"", ""},
@@ -28,7 +79,223 @@ func TestFirstNchars(t *testing.T) {
 	}
 }
 
-func TestShorten(t *testing.T) {
+func TestShortenNegative(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters (nothing changes)
+		{"", ""},
+		// 304 characters -> 304 characters (nothing changes)
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit."},
+		// 400 characters -> 400 characters (nothing changes)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it."},
+		// 402 characters -> 402 characters (nothing changes)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste."},
+		// 445 characters -> 445 characters (nothing changes)
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, -1)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShortenZero(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 0 characters (no room for suffix)
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", ""},
+		// 400 characters -> 0 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", ""},
+		// 402 characters -> 0 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", ""},
+		// 445 characters -> 0 characters (no room for suffix)
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", ""},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 0)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShorten1(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 1 character (no room for suffix)
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "K"},
+		// 400 characters -> 1 character (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "A"},
+		// 402 characters -> 1 character (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "A"},
+		// 445 characters -> 1 character (no room for suffix)
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "L"},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 1)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShorten2(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 2 characters (no room for suffix)
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "Kn"},
+		// 400 characters -> 2 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "Ap"},
+		// 402 characters -> 2 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "Ap"},
+		// 445 characters -> 2 characters (no room for suffix)
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lo"},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 2)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShorten3(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 3 characters (no room for suffix)
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "Kno"},
+		// 400 characters -> 3 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "Apa"},
+		// 402 characters -> 3 characters (no room for suffix)
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "Apa"},
+		// 445 characters -> 3 characters (no room for suffix)
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "Lor"},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 3)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShorten4(t *testing.T) {
+	// original string, expected string
+	tests := []testPair{
+		// 0 characters -> 0 characters
+		{"", ""},
+		// 304 characters -> 4 characters with ... as the last 3 characters
+		{"Knowing the word count of a text can be important. For example, if an author has to write a minimum or maximum amount of words for an article, essay, report, story, book, paper, you name it. WordCounter will help to make sure its word count reaches a specific requirement or stays within a certain limit.", "K..."},
+		// 400 characters -> 4 characters with ... as the last 3 characters
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit. You can also copy and paste it.", "A..."},
+		// 402 characters -> 4 characters with ... as the last 3 characters
+		{"Apart from counting words and characters, our online editor can help you to improve word choice and writing style, and, optionally, help you to detect grammar mistakes and plagiarism. To check word count simply place your cursor into the text box above and start typing. You'll see the number of characters and words increase or decrease as you type, delete, and edit them. You can also copy and paste.", "A..."},
+		// 445 characters -> 4 characters with ... as the last 3 characters
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "L..."},
+	}
+
+	// create test results
+	var results = make([]result.Result, 0, len(tests))
+	for _, test := range tests {
+		v := result.Result{
+			Description: test.orig,
+		}
+		results = append(results, v)
+	}
+
+	// shorten the descriptions
+	result.Shorten(results, 4)
+
+	// check if the descriptions are shortened as expected
+	for i, test := range tests {
+		v := results[i].Description
+		if v != test.expected {
+			t.Errorf("\n\tShorten(%q)\n\tlen = %v\n\n\tGot: %q\n\tlen = %v\n\n\tWant: %q\n\tlen = %v", test.orig, len(test.orig), v, len(v), test.expected, len(test.expected))
+		}
+	}
+}
+
+func TestShorten400(t *testing.T) {
 	// original string, expected string
 	tests := []testPair{
 		// 0 characters -> 0 characters

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -40,6 +40,7 @@ func Search(query string, options engines.Options, db cache.DB, settings map[eng
 
 		// the main line
 		results = PerformSearch(query, options, settings, categories)
+		result.Shorten(results, 2500)
 	}
 
 	return results, foundInDB


### PR DESCRIPTION
Closes https://github.com/hearchco/frontend/issues/159

The bug was that the code was modifying a copy of slice element instead of the actual element. Also, decided to move the functionality to search func instead of only when returning the results via router and to modify the passed slice instead of making a copy.

Had to switch from:
```go
for _, result := range results {
  ...
}
```

To:
```go
for i := range results {
  result := &results[i]
  ...
}
```