### PR TITLE
fix(results,router,category)!: cleaner output of results with snakecase

### DIFF
--- a/src/router/search.go
+++ b/src/router/search.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hearchco/hearchco/src/search"
 	"github.com/hearchco/hearchco/src/search/category"
 	"github.com/hearchco/hearchco/src/search/engines"
+	"github.com/hearchco/hearchco/src/search/result"
 )
 
 // returns response body, header and error
@@ -148,8 +149,17 @@ func Search(w http.ResponseWriter, r *http.Request, db cache.DB, ttlConf config.
 	// search for results in db and web, afterwards return JSON
 	results, foundInDB := search.Search(query, options, db, settings, categories, salt)
 
+	// get category from query or options
+	cat := category.FromQueryWithFallback(query, options.Category)
+
 	// send response as soon as possible
-	err = writeResponseJSON(w, http.StatusOK, results)
+	if cat == category.IMAGES {
+		resultsOutput := result.ConvertToImageOutput(results)
+		err = writeResponseJSON(w, http.StatusOK, resultsOutput)
+	} else {
+		resultsOutput := result.ConvertToGeneralOutput(results)
+		err = writeResponseJSON(w, http.StatusOK, resultsOutput)
+	}
 
 	// don't return immediately, we want to cache results and update them if necessary
 	search.CacheAndUpdateResults(query, options, db, ttlConf, settings, categories, results, foundInDB, salt)

--- a/src/search/category/category.go
+++ b/src/search/category/category.go
@@ -42,3 +42,14 @@ func SafeFromString(cat string) Name {
 	}
 	return ret
 }
+
+func FromQueryWithFallback(query string, fallback Name) Name {
+	cat := FromQuery(query)
+	if cat != "" {
+		return cat
+	} else if fallback != "" {
+		return fallback
+	} else {
+		return GENERAL
+	}
+}

--- a/src/search/result/output.go
+++ b/src/search/result/output.go
@@ -1,0 +1,55 @@
+package result
+
+type GeneralResultOutput struct {
+	URL         string          `json:"url"`
+	URLHash     string          `json:"url_hash,omitempty"`
+	Rank        uint            `json:"rank"`
+	Score       float64         `json:"score"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	EngineRanks []RetrievedRank `json:"engine_ranks"`
+}
+
+func ConvertToGeneralOutput(results []Result) []GeneralResultOutput {
+	resultsOutput := make([]GeneralResultOutput, 0, len(results))
+	for _, r := range results {
+		resultsOutput = append(resultsOutput, GeneralResultOutput{
+			URL:         r.URL,
+			URLHash:     r.URLHash,
+			Rank:        r.Rank,
+			Score:       r.Score,
+			Title:       r.Title,
+			Description: r.Description,
+			EngineRanks: r.EngineRanks,
+		})
+	}
+	return resultsOutput
+}
+
+type ImageResultOutput struct {
+	URL         string          `json:"url"`
+	URLHash     string          `json:"url_hash,omitempty"`
+	Rank        uint            `json:"rank"`
+	Score       float64         `json:"score"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	EngineRanks []RetrievedRank `json:"engine_ranks"`
+	ImageResult ImageResult     `json:"image_result"`
+}
+
+func ConvertToImageOutput(results []Result) []ImageResultOutput {
+	resultsOutput := make([]ImageResultOutput, 0, len(results))
+	for _, r := range results {
+		resultsOutput = append(resultsOutput, ImageResultOutput{
+			URL:         r.URL,
+			URLHash:     r.URLHash,
+			Rank:        r.Rank,
+			Score:       r.Score,
+			Title:       r.Title,
+			Description: r.Description,
+			EngineRanks: r.EngineRanks,
+			ImageResult: r.ImageResult,
+		})
+	}
+	return resultsOutput
+}

--- a/src/search/result/result.go
+++ b/src/search/result/result.go
@@ -5,29 +5,29 @@ import (
 )
 
 type ImageFormat struct {
-	Height uint
-	Width  uint
+	Height uint `json:"height"`
+	Width  uint `json:"width"`
 }
 
 type ImageResult struct {
-	Original         ImageFormat
-	Thumbnail        ImageFormat
-	ThumbnailURL     string
-	ThumbnailURLHash string
-	Source           string
-	SourceURL        string
+	Original         ImageFormat `json:"original"`
+	Thumbnail        ImageFormat `json:"thumbnail"`
+	ThumbnailURL     string      `json:"thumbnail_url"`
+	ThumbnailURLHash string      `json:"thumbnail_url_hash,omitempty"`
+	Source           string      `json:"source"`
+	SourceURL        string      `json:"source_url"`
 }
 
 // Everything about some Result, calculated and compiled from multiple search engines
 // The URL is the primary key
 type Result struct {
-	URL         string
-	URLHash     string
-	Rank        uint
-	Score       float64
-	Title       string
-	Description string
-	EngineRanks []RetrievedRank
-	ImageResult ImageResult
-	Response    *colly.Response
+	URL         string          `json:"url"`
+	URLHash     string          `json:"url_hash,omitempty"`
+	Rank        uint            `json:"rank"`
+	Score       float64         `json:"score"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	EngineRanks []RetrievedRank `json:"engine_ranks"`
+	ImageResult ImageResult     `json:"image_result"`
+	Response    *colly.Response `json:"-"`
 }

--- a/src/search/result/retrieved.go
+++ b/src/search/result/retrieved.go
@@ -5,18 +5,18 @@ import "github.com/hearchco/hearchco/src/search/engines"
 // variables are 1-indexed
 // Information about what Rank a result was on some Search Engine
 type RetrievedRank struct {
-	SearchEngine engines.Name
-	Rank         uint
-	Page         uint
-	OnPageRank   uint
+	SearchEngine engines.Name `json:"search_engine"`
+	Rank         uint         `json:"rank"`
+	Page         uint         `json:"page"`
+	OnPageRank   uint         `json:"on_page_rank"`
 }
 
 // The info a Search Engine returned about some Result
 type RetrievedResult struct {
-	URL         string
-	URLHash     string
-	Title       string
-	Description string
-	ImageResult ImageResult
-	Rank        RetrievedRank
+	URL         string        `json:"url"`
+	URLHash     string        `json:"url_hash,omitempty"`
+	Title       string        `json:"title"`
+	Description string        `json:"description"`
+	ImageResult ImageResult   `json:"image_result"`
+	Rank        RetrievedRank `json:"rank"`
 }


### PR DESCRIPTION
This breaks the output, since now it's in snakecase instead of previous struct field names. Frontend will need to be adjusted for this change.

A positive is that now when requesting general results there will be no URLHash empty value and no ImageResult part of the result returned. Also, for both general and images there will be no `response: nil` returned.