### PR TITLE
fix(options)!: default values and validations from the get go

### DIFF
--- a/src/cli/climode.go
+++ b/src/cli/climode.go
@@ -57,7 +57,7 @@ func Run(flags Flags, db cache.DB, conf config.Config) {
 	log.Info().
 		Str("queryAnon", anonymize.String(flags.Query)).
 		Str("queryHash", anonymize.HashToSHA256B64(flags.Query)).
-		Int("maxPages", flags.MaxPages).
+		Int("maxPages", flags.PagesMax).
 		Bool("visit", flags.Visit).
 		Msg("Started hearching")
 
@@ -66,17 +66,16 @@ func Run(flags Flags, db cache.DB, conf config.Config) {
 		log.Fatal().Err(err).Msg("Invalid category")
 	}
 
+	// all of these have default values set and are validated beforehand
 	options := engines.Options{
-		Pages: engines.Pages{
-			Start: flags.StartPage,
-			Max:   flags.MaxPages,
-		},
 		VisitPages: flags.Visit,
-		Category:   categoryName,
-		UserAgent:  flags.UserAgent,
-		Locale:     flags.Locale,
 		SafeSearch: flags.SafeSearch,
-		Mobile:     flags.Mobile,
+		Pages: engines.Pages{
+			Start: flags.PagesStart,
+			Max:   flags.PagesMax,
+		},
+		Locale:   flags.Locale,
+		Category: categoryName,
 	}
 
 	start := time.Now()

--- a/src/cli/structs.go
+++ b/src/cli/structs.go
@@ -17,14 +17,12 @@ type Flags struct {
 	DataDirPath string `type:"path" default:"${data_folder}" env:"HEARCHCO_DATA_DIR" help:"Data folder path"`
 	Verbosity   int8   `type:"counter" default:"0" short:"v" env:"HEARCHCO_VERBOSITY" help:"Log level verbosity"`
 	// options
-	StartPage  int    `type:"counter" default:"1" env:"HEARCHCO_START_PAGE" help:"Page from which to start searching (>=1)"`
-	MaxPages   int    `type:"counter" default:"1" env:"HEARCHCO_MAX_PAGES" help:"Number of pages to search (>=1)"`
 	Visit      bool   `type:"bool" default:"false" env:"HEARCHCO_VISIT" help:"Should results be visited"`
-	Category   string `type:"string" default:"" short:"c" env:"HEARCHCO_CATEGORY" help:"Search result category. Can also be supplied through the query (e.g. \"!info smartphone\"). Supported values: info[/wiki], science[/sci], news, blog, surf, newnews[/nnews]"`
-	UserAgent  string `type:"string" default:"" env:"HEARCHCO_USER_AGENT" help:"The user agent"`
-	Locale     string `type:"string" default:"" env:"HEARCHCO_LOCALE" help:"Locale string specifying result language and region preference. The format is en_US"`
 	SafeSearch bool   `type:"bool" default:"false" env:"HEARCHCO_SAFE_SEARCH" help:"Whether to use safe search"`
-	Mobile     bool   `type:"bool" default:"false" env:"HEARCHCO_MOBILE" help:"Whether to gear results towards mobile"`
+	PagesStart int    `type:"counter" default:"1" env:"HEARCHCO_PAGES_START" help:"Page from which to start searching (>=1)"`
+	PagesMax   int    `type:"counter" default:"1" env:"HEARCHCO_PAGES_MAX" help:"Number of pages to search (>=1)"`
+	Locale     string `type:"string" default:"en_US" env:"HEARCHCO_LOCALE" help:"Locale string specifying result language and region preference. The format is en_US"`
+	Category   string `type:"string" default:"general" short:"c" env:"HEARCHCO_CATEGORY" help:"Search result category. Can also be supplied through the query (e.g. \"!images smartphone\")."`
 	// profiler
 	CPUProfile    bool `type:"bool" default:"false" env:"HEARCHCO_CPUPROFILE" help:"Use cpu profiling"`
 	HeapProfile   bool `type:"bool" default:"false" env:"HEARCHCO_HEAPPROFILE" help:"Use heap profiling"`

--- a/src/search/category/name.go
+++ b/src/search/category/name.go
@@ -10,3 +10,7 @@ const (
 	SCIENCE   Name = "science"
 	THOROUGH  Name = "thorough"
 )
+
+func (cat Name) String() string {
+	return string(cat)
+}

--- a/src/search/engines/_sedefaults/init.go
+++ b/src/search/engines/_sedefaults/init.go
@@ -9,14 +9,35 @@ import (
 	"github.com/hearchco/hearchco/src/config"
 	"github.com/hearchco/hearchco/src/search/bucket"
 	"github.com/hearchco/hearchco/src/search/engines"
+	"github.com/hearchco/hearchco/src/search/useragent"
 	"github.com/rs/zerolog/log"
 )
 
-// it's okay to return pointers to collectors since colly.NewCollector() returns a pointer
 func InitializeCollectors(ctx context.Context, engineName engines.Name, options engines.Options, settings config.Settings, timings config.CategoryTimings, relay *bucket.Relay) (*colly.Collector, *colly.Collector) {
-	col := colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent), colly.Async())
-	pagesCol := colly.NewCollector(colly.MaxDepth(1), colly.UserAgent(options.UserAgent), colly.Async())
+	// get random user agent and corresponding Sec-Ch-Ua header
+	userAgent, secChUa := useragent.RandomUserAgentWithHeader()
 
+	// create collectors
+	col := colly.NewCollector(
+		colly.Async(),
+		colly.MaxDepth(1),
+		colly.UserAgent(userAgent),
+		colly.IgnoreRobotsTxt(),
+		colly.Headers(map[string]string{
+			"Sec-Ch-Ua": secChUa,
+		}),
+	)
+	pagesCol := colly.NewCollector(
+		colly.Async(),
+		colly.MaxDepth(1),
+		colly.UserAgent(userAgent),
+		colly.IgnoreRobotsTxt(),
+		colly.Headers(map[string]string{
+			"Sec-Ch-Ua": secChUa,
+		}),
+	)
+
+	// set collector limit rules
 	limitRule := colly.LimitRule{
 		DomainGlob:  "*",
 		Delay:       timings.Delay,
@@ -30,12 +51,13 @@ func InitializeCollectors(ctx context.Context, engineName engines.Name, options 
 			Msg("_sedefaults.InitializeCollectors(): failed adding new limit rule")
 	}
 
+	// set collector proxies
 	if settings.Proxies != nil {
 		log.Debug().
 			Strs("proxies", settings.Proxies).
 			Msg("Using proxies")
 
-		// Rotate proxies
+		// rotate proxies
 		rp, err := proxy.RoundRobinProxySwitcher(settings.Proxies...)
 		if err != nil {
 			log.Fatal().
@@ -48,11 +70,11 @@ func InitializeCollectors(ctx context.Context, engineName engines.Name, options 
 		pagesCol.SetProxyFunc(rp)
 	}
 
-	// Set up collector
+	// set up collector
 	colRequest(col, ctx, engineName, false)
 	colError(col, engineName, false)
 
-	// Set up pages collector
+	// set up pages collector
 	colRequest(pagesCol, ctx, engineName, true)
 	colError(pagesCol, engineName, true)
 	pagesColResponse(pagesCol, engineName, relay)

--- a/src/search/engines/_sedefaults/prepare.go
+++ b/src/search/engines/_sedefaults/prepare.go
@@ -5,61 +5,32 @@ import (
 
 	"github.com/hearchco/hearchco/src/config"
 	"github.com/hearchco/hearchco/src/search/engines"
-	"github.com/hearchco/hearchco/src/search/useragent"
 	"github.com/rs/zerolog/log"
 )
 
-// sending options and settings as pointers since they are modified
-func Prepare(ctx context.Context, info engines.Info, support engines.SupportedSettings, options *engines.Options, settings *config.Settings) (context.Context, error) {
-	seName := info.Name
-
-	if options.UserAgent == "" {
-		options.UserAgent = useragent.RandomUserAgent()
-	}
-	log.Trace().
-		Str("engine", seName.String()).
-		Str("userAgent", options.UserAgent).
-		Msg("Prepare")
-
-	// TODO: move to config.SetupConfig
+func Prepare(ctx context.Context, info engines.Info, support engines.SupportedSettings, options engines.Options, settings config.Settings) (context.Context, error) {
+	// TODO: move to config initialization
 	if settings.RequestedResultsPerPage != 0 && !support.RequestedResultsPerPage {
 		log.Panic().
-			Str("engine", seName.String()).
+			Caller().
+			Str("engine", info.Name.String()).
 			Int("requestedResultsPerPage", settings.RequestedResultsPerPage).
-			Msg("_sedefaults.Prepare(): setting not supported by engine")
+			Msg("Setting not supported by engine")
 		// ^PANIC
-	}
-	if settings.RequestedResultsPerPage == 0 && support.RequestedResultsPerPage {
-		// if its used in the code but not set, give it the default value
-		settings.RequestedResultsPerPage = info.ResultsPerPage
-	}
-
-	if options.Mobile && !support.Mobile {
-		options.Mobile = false // this line shouldn't matter [1]
-		log.Debug().
-			Str("engine", seName.String()).
-			Bool("mobile", options.Mobile).
-			Msg("Mobile set but not supported")
 	}
 
 	if options.Locale != "" && !support.Locale {
-		options.Locale = config.DefaultLocale // [1]
 		log.Debug().
-			Str("engine", seName.String()).
+			Str("engine", info.Name.String()).
 			Str("locale", options.Locale).
-			Msg("Locale set but not supported")
-	}
-
-	if options.Locale == "" && support.Locale {
-		options.Locale = config.DefaultLocale
+			Msg("Setting not supported by engine")
 	}
 
 	if options.SafeSearch && !support.SafeSearch {
-		options.SafeSearch = false // [1]
 		log.Debug().
-			Str("engine", seName.String()).
+			Str("engine", info.Name.String()).
 			Bool("safeSearch", options.SafeSearch).
-			Msg("SafeSearch set but not supported")
+			Msg("Setting not supported by engine")
 	}
 
 	if ctx == nil {

--- a/src/search/engines/bing/bing.go
+++ b/src/search/engines/bing/bing.go
@@ -23,7 +23,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/bingimages/bingimages.go
+++ b/src/search/engines/bingimages/bingimages.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/brave/brave.go
+++ b/src/search/engines/brave/brave.go
@@ -20,7 +20,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/duckduckgo/duckduckgo.go
+++ b/src/search/engines/duckduckgo/duckduckgo.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/etools/etools.go
+++ b/src/search/engines/etools/etools.go
@@ -20,7 +20,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/google/google.go
+++ b/src/search/engines/google/google.go
@@ -19,7 +19,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/googleimages/googleimages.go
+++ b/src/search/engines/googleimages/googleimages.go
@@ -23,7 +23,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/googlescholar/googlescholar.go
+++ b/src/search/engines/googlescholar/googlescholar.go
@@ -21,7 +21,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/mojeek/mojeek.go
+++ b/src/search/engines/mojeek/mojeek.go
@@ -20,7 +20,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/presearch/presearch.go
+++ b/src/search/engines/presearch/presearch.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/qwant/options.go
+++ b/src/search/engines/qwant/options.go
@@ -14,6 +14,5 @@ var Info = engines.Info{
 var Support = engines.SupportedSettings{
 	Locale:                  true,
 	SafeSearch:              true,
-	Mobile:                  true,
 	RequestedResultsPerPage: true,
 }

--- a/src/search/engines/qwant/qwant.go
+++ b/src/search/engines/qwant/qwant.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}
@@ -71,7 +71,6 @@ func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, o
 
 	// static params
 	localeParam := getLocale(options)
-	deviceParam := getDevice(options)
 	safeSearchParam := getSafeSearch(options)
 	countParam := "&count=" + strconv.Itoa(settings.RequestedResultsPerPage)
 
@@ -84,7 +83,7 @@ func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, o
 		offsetParam := "&offset=" + strconv.Itoa(i*settings.RequestedResultsPerPage)
 
 		urll := Info.URL + query + countParam + localeParam + offsetParam + safeSearchParam
-		anonUrll := Info.URL + anonymize.String(query) + countParam + localeParam + offsetParam + deviceParam + safeSearchParam
+		anonUrll := Info.URL + anonymize.String(query) + countParam + localeParam + offsetParam + safeSearchParam
 
 		err := _sedefaults.DoGetRequest(urll, anonUrll, colCtx, col, Info.Name)
 		if err != nil {
@@ -113,13 +112,6 @@ func getLocale(options engines.Options) string {
 		Strs("validLocales", validLocales[:]).
 		Msg("qwant.getLocale(): Invalid qwant locale supplied. Falling back to en_US. Qwant supports these (disregard specific formatting)")
 	return "&locale=" + strings.ToLower(config.DefaultLocale)
-}
-
-func getDevice(options engines.Options) string {
-	if options.Mobile {
-		return "&device=mobile"
-	}
-	return "&device=desktop"
 }
 
 func getSafeSearch(options engines.Options) string {

--- a/src/search/engines/startpage/startpage.go
+++ b/src/search/engines/startpage/startpage.go
@@ -21,7 +21,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/structs.go
+++ b/src/search/engines/structs.go
@@ -9,7 +9,6 @@ import (
 type SupportedSettings struct {
 	Locale                  bool
 	SafeSearch              bool
-	Mobile                  bool
 	RequestedResultsPerPage bool
 }
 
@@ -34,14 +33,11 @@ type Pages struct {
 }
 
 type Options struct {
-	VisitPages    bool
-	SafeSearch    bool
-	Mobile        bool
-	JustFirstPage bool
-	Pages         Pages
-	UserAgent     string
-	Locale        string //format: en_US
-	Category      category.Name
+	VisitPages bool
+	SafeSearch bool
+	Pages      Pages
+	Locale     string // format: en_US
+	Category   category.Name
 }
 
 func ValidateLocale(locale string) error {

--- a/src/search/engines/swisscows/swisscows.go
+++ b/src/search/engines/swisscows/swisscows.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/yahoo/yahoo.go
+++ b/src/search/engines/yahoo/yahoo.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}

--- a/src/search/engines/yep/yep.go
+++ b/src/search/engines/yep/yep.go
@@ -22,7 +22,7 @@ func New() Engine {
 }
 
 func (e Engine) Search(ctx context.Context, query string, relay *bucket.Relay, options engines.Options, settings config.Settings, timings config.CategoryTimings, salt string, nEnabledEngines int) []error {
-	ctx, err := _sedefaults.Prepare(ctx, Info, Support, &options, &settings)
+	ctx, err := _sedefaults.Prepare(ctx, Info, Support, options, settings)
 	if err != nil {
 		return []error{err}
 	}


### PR DESCRIPTION
- [x] Both CLI and HTTP mode have all the options set with defaults and are validated (so no need to check again in colly prepare), and now options aren't being changed (so no need to pass as pointer)
- [x] BREAKING: Removed some options
  - JustFirstPage (wasn't being used anywhere)
  - Mobile (only Qwant supported it and could compromise privacy if it's not the same for all users)
  - User Agent (if users set a wrong one a server could easily get it's IP banned, also it compromises users privacy if it differs from other users)