### PR TITLE
feat: Favicons proxy

### DIFF
--- a/src/router/routes/route_proxy.go
+++ b/src/router/routes/route_proxy.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
@@ -29,37 +31,104 @@ func routeProxy(w http.ResponseWriter, r *http.Request, salt string, timeouts co
 
 	urlParam := getParamOrDefault(params, "url")
 	hashParam := getParamOrDefault(params, "hash")
+	faviconParam := getParamOrDefault(params, "favicon", strconv.FormatBool(false))
 
 	if urlParam == "" || hashParam == "" {
 		// User error.
 		return writeResponse(w, http.StatusBadRequest, "url and hash are required")
 	}
 
+	urlToProxy := urlParam
+	if val, err := strconv.ParseBool(faviconParam); err != nil {
+		// User error.
+		return writeResponse(w, http.StatusBadRequest, "favicon must be a boolean")
+	} else if val {
+		faviconUrl, err := getFaviconURL(urlParam)
+		if err != nil {
+			// User error.
+			log.Debug().
+				Err(err).
+				Str("url", urlParam).
+				Str("favicon", faviconUrl).
+				Msg("Failed to create favicon URL")
+			return writeResponse(w, http.StatusBadRequest, err.Error())
+		} else {
+			urlToProxy = faviconUrl
+		}
+	}
+
 	// Check if hash is valid.
-	if !anonymize.VerifyHash(hashParam, urlParam, salt) {
+	if !anonymize.VerifyHash(hashParam, urlToProxy, salt) {
 		// User error.
 		log.Debug().
 			Str("url", urlParam).
+			Str("url_to_proxy", urlToProxy).
 			Str("hash", hashParam).
+			Str("favicon", faviconParam).
 			Msg("Invalid hash")
 		return writeResponse(w, http.StatusUnauthorized, "invalid hash")
 	}
 
 	// Parse the url.
-	target, err := url.Parse(urlParam)
+	target, err := url.Parse(urlToProxy)
 	if err != nil {
 		// User error.
 		log.Debug().
-			Str("url", urlParam).
+			Str("url", urlToProxy).
 			Msg("Invalid url")
 		return writeResponse(w, http.StatusBadRequest, "invalid url")
 	}
 
+	// Create a new request.
+	nr := createAnonRequest(r, target)
+	log.Trace().
+		Caller().
+		Str("request", fmt.Sprint(nr)).
+		Msg("Created a new anon request")
+
+	// Create reverse proxy with timeout.
+	rp := createReverseProxy(timeouts)
+
+	// Proxy the request.
+	log.Debug().
+		Str("url", target.String()).
+		Msg("Proxying request")
+	rp.ServeHTTP(w, &nr) // Use the new request.
+
+	return nil
+}
+
+// Appends the path to favicon to the URI of the URL.
+func getFaviconURL(urll string) (string, error) {
+	// TODO: Impl getting the favicon path from the html head.
+	const faviconPath = "/favicon.ico"
+	uri, err := getURI(urll)
+	if err != nil {
+		return "", err
+	} else {
+		return uri + faviconPath, nil
+	}
+}
+
+// Extracts the URI from the URL.
+// https://www.example.com/some/path -> https://www.example.com
+func getURI(urll string) (string, error) {
+	const uriPattern = "^(http(s?))(://)([^/]+)"
+	re := regexp.MustCompile(uriPattern)
+	ss := re.FindString(urll)
+	if ss == "" {
+		return "", fmt.Errorf("failed to extract URI from URL")
+	} else {
+		return ss, nil
+	}
+}
+
+func createAnonRequest(r *http.Request, target *url.URL) http.Request {
 	// Get random UserAgent with corresponding Sec-Ch-Ua headers.
 	ua := useragent.RandomUserAgentWithHeaders()
 
 	// Create a new request.
-	nr := &http.Request{
+	return http.Request{
 		Method:     http.MethodGet,
 		URL:        target,
 		Host:       target.Host,
@@ -80,12 +149,9 @@ func routeProxy(w http.ResponseWriter, r *http.Request, salt string, timeouts co
 			"User-Agent":         {ua.UserAgent},
 		},
 	}
+}
 
-	log.Trace().
-		Caller().
-		Str("request", fmt.Sprint(nr)).
-		Msg("Created a new request")
-
+func createReverseProxy(timeouts config.ImageProxyTimeouts) httputil.ReverseProxy {
 	// Create reverse proxy with timeout.
 	rp := httputil.ReverseProxy{Director: func(r *http.Request) {}}
 	rp.Transport = &http.Transport{
@@ -95,12 +161,5 @@ func routeProxy(w http.ResponseWriter, r *http.Request, salt string, timeouts co
 		}).DialContext,
 		TLSHandshakeTimeout: timeouts.TLSHandshake,
 	}
-
-	// Proxy the request.
-	log.Debug().
-		Str("url", target.String()).
-		Msg("Proxying request")
-	rp.ServeHTTP(w, nr) // Use the new request.
-
-	return nil
+	return rp
 }

--- a/src/search/result/general.go
+++ b/src/search/result/general.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"github.com/hearchco/agent/src/utils/anonymize"
+	"github.com/hearchco/agent/src/utils/moreurls"
 	"github.com/rs/zerolog/log"
 )
 
@@ -96,5 +98,18 @@ func (r *General) AppendEngineRanks(rank Rank) {
 }
 
 func (r General) ConvertToOutput(salt string) ResultOutput {
-	return r
+	urlToVerify, err := moreurls.GetURIToVerify(r.URL())
+	if err != nil {
+		log.Panic().
+			Err(err).
+			Str("url", r.URL()).
+			Msg("Failed to get URI to verify")
+		// ^PANIC - This should never happen.
+	}
+	return GeneralOutput{
+		generalOutputJSON{
+			r,
+			anonymize.HashToSHA256B64Salted(urlToVerify, salt),
+		},
+	}
 }

--- a/src/search/result/general_output.go
+++ b/src/search/result/general_output.go
@@ -1,0 +1,11 @@
+package result
+
+type GeneralOutput struct {
+	generalOutputJSON
+}
+
+type generalOutputJSON struct {
+	General
+
+	FaviconHash string `json:"favicon_hash,omitempty"`
+}

--- a/src/utils/moreurls/verify.go
+++ b/src/utils/moreurls/verify.go
@@ -1,0 +1,33 @@
+package moreurls
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	faviconVerifierPrefix = "favicon-verify://"
+	uriPattern            = "^(http(s?))(://)([^/]+)"
+)
+
+// Prepends the URI with the favicon-verify prefix.
+func GetURIToVerify(urll string) (string, error) {
+	uri, err := GetURI(urll)
+	if err != nil {
+		return "", err
+	} else {
+		return faviconVerifierPrefix + uri, nil
+	}
+}
+
+// Extracts the URI from the URL.
+// https://www.example.com/some/path -> https://www.example.com
+func GetURI(urll string) (string, error) {
+	re := regexp.MustCompile(uriPattern)
+	ss := re.FindString(urll)
+	if ss == "" {
+		return "", fmt.Errorf("failed to extract URI from URL")
+	} else {
+		return ss, nil
+	}
+}


### PR DESCRIPTION
This currently hardcodes the url of favicon to be site `<site_URI>/favicon.ico`, but that is enough for most websites. Later on scraping from HTML's head will added to actually detect where the favicon is.