### PR TITLE
fix(imageproxy): switch to get and copy body instead of reverse proxy

### DIFF
--- a/src/config/defaults.go
+++ b/src/config/defaults.go
@@ -25,11 +25,7 @@ func New() Config {
 				},
 			},
 			ImageProxy: ImageProxy{
-				Timeouts: ImageProxyTimeouts{
-					Dial:         3 * time.Second,
-					KeepAlive:    3 * time.Second,
-					TLSHandshake: 2 * time.Second,
-				},
+				Timeout: 3 * time.Second,
 			},
 		},
 		Categories: map[category.Name]Category{

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -85,12 +85,8 @@ func (c Config) getReader() ReaderConfig {
 				Redis: c.Server.Cache.Redis,
 			},
 			ImageProxy: ReaderImageProxy{
-				Salt: c.Server.ImageProxy.Salt,
-				Timeouts: ReaderImageProxyTimeouts{
-					Dial:         moretime.ConvertToFancyTime(c.Server.ImageProxy.Timeouts.Dial),
-					KeepAlive:    moretime.ConvertToFancyTime(c.Server.ImageProxy.Timeouts.KeepAlive),
-					TLSHandshake: moretime.ConvertToFancyTime(c.Server.ImageProxy.Timeouts.TLSHandshake),
-				},
+				Salt:    c.Server.ImageProxy.Salt,
+				Timeout: moretime.ConvertToFancyTime(c.Server.ImageProxy.Timeout),
 			},
 		},
 		// Initialize the categories map.
@@ -153,12 +149,8 @@ func (c *Config) fromReader(rc ReaderConfig) {
 				Redis: rc.Server.Cache.Redis,
 			},
 			ImageProxy: ImageProxy{
-				Salt: rc.Server.ImageProxy.Salt,
-				Timeouts: ImageProxyTimeouts{
-					Dial:         moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeouts.Dial),
-					KeepAlive:    moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeouts.KeepAlive),
-					TLSHandshake: moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeouts.TLSHandshake),
-				},
+				Salt:    rc.Server.ImageProxy.Salt,
+				Timeout: moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeout),
 			},
 		},
 		// Initialize the categories map.

--- a/src/config/structs_server.go
+++ b/src/config/structs_server.go
@@ -76,26 +76,14 @@ type Redis struct {
 }
 
 // ReaderProxy is format in which the config is read from the config file and environment variables.
-type ReaderImageProxy struct {
-	Salt     string                   `koanf:"salt"`
-	Timeouts ReaderImageProxyTimeouts `koanf:"timeouts"`
-}
-type ImageProxy struct {
-	Salt     string
-	Timeouts ImageProxyTimeouts
-}
-
-// ReaderProxyTimeouts is format in which the config is read from the config file and environment variables.
 // In <number><unit> format.
 // Example: 1s, 1m, 1h, 1d, 1w, 1M, 1y.
 // If unit is not specified, it is assumed to be milliseconds.
-type ReaderImageProxyTimeouts struct {
-	Dial         string `koanf:"dial"`
-	KeepAlive    string `koanf:"keepalive"`
-	TLSHandshake string `koanf:"tlshandshake"`
+type ReaderImageProxy struct {
+	Salt    string `koanf:"salt"`
+	Timeout string `koanf:"timeout"`
 }
-type ImageProxyTimeouts struct {
-	Dial         time.Duration
-	KeepAlive    time.Duration
-	TLSHandshake time.Duration
+type ImageProxy struct {
+	Salt    string
+	Timeout time.Duration
 }

--- a/src/router/routes/responses.go
+++ b/src/router/routes/responses.go
@@ -1,10 +1,6 @@
 package routes
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-
 	"github.com/hearchco/agent/src/search/result"
 )
 
@@ -28,45 +24,4 @@ type SuggestionsResponse struct {
 	responseBase
 
 	Suggestions []result.Suggestion `json:"suggestions"`
-}
-
-func writeResponse(w http.ResponseWriter, status int, body string) error {
-	w.WriteHeader(status)
-	_, err := w.Write([]byte(body))
-	return err
-}
-
-func writeResponseJSON(w http.ResponseWriter, status int, body any) error {
-	res, err := json.Marshal(body)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, werr := w.Write([]byte("internal server error"))
-		if werr != nil {
-			return fmt.Errorf("%w: %w", werr, err)
-		}
-		return err
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_, err = w.Write(res)
-	return err
-}
-
-func writeResponseSuggestions(w http.ResponseWriter, status int, query string, suggestions []string) error {
-	jsonStruct := [...]any{query, suggestions}
-	res, err := json.Marshal(jsonStruct)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, werr := w.Write([]byte("internal server error"))
-		if werr != nil {
-			return fmt.Errorf("%w: %w", werr, err)
-		}
-		return err
-	}
-
-	w.Header().Set("Content-Type", "application/x-suggestions+json")
-	w.WriteHeader(status)
-	_, err = w.Write(res)
-	return err
 }

--- a/src/router/routes/setup.go
+++ b/src/router/routes/setup.go
@@ -82,7 +82,7 @@ func Setup(mux *chi.Mux, ver string, db cache.DB, conf config.Config) {
 
 	// /proxy
 	mux.Get("/proxy", func(w http.ResponseWriter, r *http.Request) {
-		err := routeProxy(w, r, conf.Server.ImageProxy.Salt, conf.Server.ImageProxy.Timeouts)
+		err := routeProxy(w, r, conf.Server.ImageProxy.Salt, conf.Server.ImageProxy.Timeout)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/src/router/routes/writers.go
+++ b/src/router/routes/writers.go
@@ -1,0 +1,58 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func writeResponse(w http.ResponseWriter, status int, body string) error {
+	w.WriteHeader(status)
+	_, err := w.Write([]byte(body))
+	return err
+}
+
+func writeResponseJSON(w http.ResponseWriter, status int, body any) error {
+	res, err := json.Marshal(body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, werr := w.Write([]byte("internal server error"))
+		if werr != nil {
+			return fmt.Errorf("%w: %w", werr, err)
+		}
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, err = w.Write(res)
+	return err
+}
+
+func writeResponseSuggestions(w http.ResponseWriter, status int, query string, suggestions []string) error {
+	jsonStruct := [...]any{query, suggestions}
+	res, err := json.Marshal(jsonStruct)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, werr := w.Write([]byte("internal server error"))
+		if werr != nil {
+			return fmt.Errorf("%w: %w", werr, err)
+		}
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/x-suggestions+json")
+	w.WriteHeader(status)
+	_, err = w.Write(res)
+	return err
+}
+
+func writeResponseImageProxy(w http.ResponseWriter, resp *http.Response) error {
+	w.Header().Set("Content-Encoding", resp.Header.Get("Content-Encoding"))
+	w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	w.WriteHeader(resp.StatusCode)
+	_, err := io.Copy(w, resp.Body)
+	return err
+}


### PR DESCRIPTION
This fixes a bug where the authorized URLs for favicons would reverse proxy the authorization back to the client, which is very weird to see :)

Also, clients now load less data (only the body and 3 required headers), and only if the requested URL is an actual image with OK 200 response.

**BREAKING**: Config for image proxy timeout has changed from multiple values to a single value.