### PR TITLE
feat(proxy): make hashes expire after time

### DIFF
--- a/src/config/load.go
+++ b/src/config/load.go
@@ -88,7 +88,7 @@ func (c Config) getReader() ReaderConfig {
 				DynamoDB: c.Server.Cache.DynamoDB,
 			},
 			ImageProxy: ReaderImageProxy{
-				SecretKey: c.Server.ImageProxy.Salt,
+				SecretKey: c.Server.ImageProxy.SecretKey,
 				Timeout:   moretime.ConvertToFancyTime(c.Server.ImageProxy.Timeout),
 			},
 		},
@@ -168,8 +168,8 @@ func (c *Config) fromReader(rc ReaderConfig) {
 				DynamoDB: rc.Server.Cache.DynamoDB,
 			},
 			ImageProxy: ImageProxy{
-				Salt:    rc.Server.ImageProxy.SecretKey,
-				Timeout: moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeout),
+				SecretKey: rc.Server.ImageProxy.SecretKey,
+				Timeout:   moretime.ConvertFromFancyTime(rc.Server.ImageProxy.Timeout),
 			},
 		},
 		// Initialize the categories map.

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -150,7 +150,7 @@ func (c *Config) fromReader(rc ReaderConfig) {
 	if rc.Server.ImageProxy.SecretKey == "" {
 		log.Fatal().
 			Caller().
-			Msg("Image proxy salt is empty")
+			Msg("Image proxy secret key is empty")
 	}
 
 	nc := Config{

--- a/src/config/structs_server.go
+++ b/src/config/structs_server.go
@@ -96,6 +96,6 @@ type ReaderImageProxy struct {
 	Timeout   string `koanf:"timeout"`
 }
 type ImageProxy struct {
-	Salt    string
-	Timeout time.Duration
+	SecretKey string
+	Timeout   time.Duration
 }

--- a/src/router/routes/route_search.go
+++ b/src/router/routes/route_search.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hearchco/agent/src/utils/gotypelimits"
 )
 
-func routeSearch(w http.ResponseWriter, r *http.Request, ver string, catsConf map[category.Name]config.Category, salt string) error {
+func routeSearch(w http.ResponseWriter, r *http.Request, ver string, catsConf map[category.Name]config.Category, secret string) error {
 	// Capture start time.
 	startTime := time.Now()
 
@@ -150,7 +150,7 @@ func routeSearch(w http.ResponseWriter, r *http.Request, ver string, catsConf ma
 	rankedRes.Rank(catsConf[categoryName].Ranking)
 
 	// Convert the results to include the hashes (output format).
-	outpusRes := result.ConvertToOutput(rankedRes, salt)
+	outpusRes := result.ConvertToOutput(rankedRes, secret)
 
 	// Create the response.
 	res := ResultsResponse{

--- a/src/router/routes/setup.go
+++ b/src/router/routes/setup.go
@@ -38,7 +38,7 @@ func Setup(mux *chi.Mux, ver string, db cache.DB, conf config.Config) {
 
 	// /search
 	mux.Get("/search", func(w http.ResponseWriter, r *http.Request) {
-		err := routeSearch(w, r, ver, conf.Categories, conf.Server.ImageProxy.Salt)
+		err := routeSearch(w, r, ver, conf.Categories, conf.Server.ImageProxy.SecretKey)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -48,7 +48,7 @@ func Setup(mux *chi.Mux, ver string, db cache.DB, conf config.Config) {
 		}
 	})
 	mux.Post("/search", func(w http.ResponseWriter, r *http.Request) {
-		err := routeSearch(w, r, ver, conf.Categories, conf.Server.ImageProxy.Salt)
+		err := routeSearch(w, r, ver, conf.Categories, conf.Server.ImageProxy.SecretKey)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -126,7 +126,7 @@ func Setup(mux *chi.Mux, ver string, db cache.DB, conf config.Config) {
 
 	// /proxy
 	mux.Get("/proxy", func(w http.ResponseWriter, r *http.Request) {
-		err := routeProxy(w, r, conf.Server.ImageProxy.Salt, conf.Server.ImageProxy.Timeout)
+		err := routeProxy(w, r, conf.Server.ImageProxy.SecretKey, conf.Server.ImageProxy.Timeout)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/src/search/result/general.go
+++ b/src/search/result/general.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"time"
+
 	"github.com/hearchco/agent/src/utils/anonymize"
 	"github.com/hearchco/agent/src/utils/moreurls"
 	"github.com/rs/zerolog/log"
@@ -106,10 +108,13 @@ func (r General) ConvertToOutput(salt string) ResultOutput {
 			Msg("Failed to get URI to verify")
 		// ^PANIC - This should never happen.
 	}
+
+	hash, timestamp := anonymize.CalculateHMACBase64(urlToVerify, salt, time.Now())
 	return GeneralOutput{
 		generalOutputJSON{
 			r,
-			anonymize.CalculateHMACBase64(urlToVerify, salt),
+			hash,
+			timestamp,
 		},
 	}
 }

--- a/src/search/result/general.go
+++ b/src/search/result/general.go
@@ -99,7 +99,7 @@ func (r *General) AppendEngineRanks(rank Rank) {
 	r.generalJSON.EngineRanks = append(r.generalJSON.EngineRanks, rank)
 }
 
-func (r General) ConvertToOutput(salt string) ResultOutput {
+func (r General) ConvertToOutput(secret string) ResultOutput {
 	urlToVerify, err := moreurls.GetURIToVerify(r.URL())
 	if err != nil {
 		log.Panic().
@@ -109,7 +109,7 @@ func (r General) ConvertToOutput(salt string) ResultOutput {
 		// ^PANIC - This should never happen.
 	}
 
-	hash, timestamp := anonymize.CalculateHMACBase64(urlToVerify, salt, time.Now())
+	hash, timestamp := anonymize.CalculateHMACBase64(urlToVerify, secret, time.Now())
 	return GeneralOutput{
 		generalOutputJSON{
 			r,

--- a/src/search/result/general_output.go
+++ b/src/search/result/general_output.go
@@ -7,5 +7,6 @@ type GeneralOutput struct {
 type generalOutputJSON struct {
 	General
 
-	FaviconHash string `json:"favicon_hash,omitempty"`
+	FaviconHash          string `json:"favicon_hash,omitempty"`
+	FaviconHashTimestamp string `json:"favicon_hash_timestamp,omitempty"`
 }

--- a/src/search/result/images.go
+++ b/src/search/result/images.go
@@ -68,9 +68,9 @@ func (r Images) SourceURL() string {
 	return r.imagesJSON.SourceURL
 }
 
-func (r Images) ConvertToOutput(salt string) ResultOutput {
-	urlHash, urlTimestamp := anonymize.CalculateHMACBase64(r.URL(), salt, time.Now())
-	thmbHash, thmbTimestamp := anonymize.CalculateHMACBase64(r.ThumbnailURL(), salt, time.Now())
+func (r Images) ConvertToOutput(secret string) ResultOutput {
+	urlHash, urlTimestamp := anonymize.CalculateHMACBase64(r.URL(), secret, time.Now())
+	thmbHash, thmbTimestamp := anonymize.CalculateHMACBase64(r.ThumbnailURL(), secret, time.Now())
 
 	return ImagesOutput{
 		imagesOutputJSON{

--- a/src/search/result/images.go
+++ b/src/search/result/images.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"time"
+
 	"github.com/rs/zerolog/log"
 
 	"github.com/hearchco/agent/src/utils/anonymize"
@@ -67,11 +69,16 @@ func (r Images) SourceURL() string {
 }
 
 func (r Images) ConvertToOutput(salt string) ResultOutput {
+	urlHash, urlTimestamp := anonymize.CalculateHMACBase64(r.URL(), salt, time.Now())
+	thmbHash, thmbTimestamp := anonymize.CalculateHMACBase64(r.ThumbnailURL(), salt, time.Now())
+
 	return ImagesOutput{
 		imagesOutputJSON{
 			r,
-			anonymize.CalculateHMACBase64(r.URL(), salt),
-			anonymize.CalculateHMACBase64(r.ThumbnailURL(), salt),
+			urlHash,
+			urlTimestamp,
+			thmbHash,
+			thmbTimestamp,
 		},
 	}
 }

--- a/src/search/result/images_output.go
+++ b/src/search/result/images_output.go
@@ -7,6 +7,8 @@ type ImagesOutput struct {
 type imagesOutputJSON struct {
 	Images
 
-	URLHash          string `json:"url_hash,omitempty"`
-	ThumbnailURLHash string `json:"thumbnail_url_hash,omitempty"`
+	URLHash                   string `json:"url_hash,omitempty"`
+	URLHashTimestamp          string `json:"url_hash_timestamp,omitempty"`
+	ThumbnailURLHash          string `json:"thumbnail_url_hash,omitempty"`
+	ThumbnailURLHashTimestamp string `json:"thumbnail_url_hash_timestamp,omitempty"`
 }

--- a/src/search/result/output.go
+++ b/src/search/result/output.go
@@ -2,10 +2,10 @@ package result
 
 type ResultOutput any
 
-func ConvertToOutput(results []Result, salt string) []ResultOutput {
+func ConvertToOutput(results []Result, secret string) []ResultOutput {
 	var output = make([]ResultOutput, 0, len(results))
 	for _, r := range results {
-		output = append(output, r.ConvertToOutput(salt))
+		output = append(output, r.ConvertToOutput(secret))
 	}
 	return output
 }

--- a/src/utils/anonymize/hash.go
+++ b/src/utils/anonymize/hash.go
@@ -4,8 +4,16 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/hearchco/agent/src/utils/moretime"
 )
 
+// Format used for the timestamps.
+const timestampFormat = time.RFC3339
+
+// Returns the hash of the message.
 func CalculateHashBase64(message string) string {
 	hasher := sha256.New()
 	hasher.Write([]byte(message))
@@ -14,14 +22,36 @@ func CalculateHashBase64(message string) string {
 	return hashedString
 }
 
-func CalculateHMACBase64(message string, key string) string {
+// Returns the hash of the message and the timestamp used to generate it.
+func CalculateHMACBase64(message, key string, t time.Time) (string, string) {
 	hasher := hmac.New(sha256.New, []byte(key))
+	timestamp := base64.URLEncoding.EncodeToString([]byte(t.Format(timestampFormat)))
+
+	hasher.Write([]byte(timestamp))
 	hasher.Write([]byte(message))
 	hashedBinary := hasher.Sum(nil)
+
 	hashedString := base64.URLEncoding.EncodeToString(hashedBinary)
-	return hashedString
+	return hashedString, timestamp
 }
 
-func VerifyHMACBase64(tag string, orig string, key string) bool {
-	return tag == CalculateHMACBase64(orig, key)
+// Returns whether the tag is valid for the given message, timestamp and key.
+func VerifyHMACBase64(tag, orig, key, timestampB64 string) (bool, error) {
+	timestamp, err := base64.URLEncoding.DecodeString(timestampB64)
+	if err != nil {
+		return false, fmt.Errorf("error decoding timestamp: %v", err)
+	}
+
+	t, err := time.Parse(timestampFormat, string(timestamp))
+	if err != nil {
+		return false, fmt.Errorf("error parsing timestamp: %v", err)
+	}
+
+	// TODO: Make duration of the timestamp configurable.
+	if time.Since(t) > moretime.Day {
+		return false, nil
+	}
+
+	verificator, _ := CalculateHMACBase64(orig, key, t)
+	return tag == verificator, nil
 }


### PR DESCRIPTION
Needs to be merged after #389 

This makes it imposible for third parties to use pictures that were returned by Hearchco as a static URL that works until the secret is changed (practically forever). For now the expiration is hard coded to be 1 day.