### PR TITLE
fix(brave): disable results being from google

### DIFF
--- a/src/search/engines/brave/info.go
+++ b/src/search/engines/brave/info.go
@@ -9,4 +9,4 @@ const (
 	searchURL = "https://search.brave.com/search"
 )
 
-var origins = [...]engines.Name{seName, engines.GOOGLE}
+var origins = [...]engines.Name{seName}


### PR DESCRIPTION
Brave results differ from Google's much more now than they did before, so it can be classified as it's own search engine.