### PR TITLE
feat(cache): results with encryption

### DIFF
--- a/src/cache/actions.go
+++ b/src/cache/actions.go
@@ -1,9 +1,0 @@
-package cache
-
-func combineIntoKey(elem ...string) string {
-	key := ""
-	for _, e := range elem {
-		key += e
-	}
-	return key
-}

--- a/src/cache/actions.go
+++ b/src/cache/actions.go
@@ -1,0 +1,9 @@
+package cache
+
+func combineIntoKey(elem ...string) string {
+	key := ""
+	for _, e := range elem {
+		key += e
+	}
+	return key
+}

--- a/src/cache/actions_currencies.go
+++ b/src/cache/actions_currencies.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hearchco/agent/src/exchange/currency"
@@ -26,17 +25,11 @@ func (db DB) GetCurrenciesTTL(base currency.Currency, engs []engines.Name) (time
 }
 
 func combineBaseWithExchangeEnginesNames(base currency.Currency, engs []engines.Name) string {
-	return fmt.Sprintf("%v_%v", base.String(), combineExchangeEnginesNames(engs))
-}
-
-func combineExchangeEnginesNames(engs []engines.Name) string {
-	var key string
-	for i, eng := range engs {
-		if i == 0 {
-			key = fmt.Sprintf("%v", eng.String())
-		} else {
-			key = fmt.Sprintf("%v_%v", key, eng.String())
-		}
+	enginesNamesStrings := make([]string, 0, len(engs)+1)
+	for _, eng := range engs {
+		enginesNamesStrings = append(enginesNamesStrings, eng.String())
 	}
-	return key
+
+	baseWithEnginesNamesStrings := append(enginesNamesStrings, base.String())
+	return combineIntoKey(baseWithEnginesNamesStrings...)
 }

--- a/src/cache/actions_currencies.go
+++ b/src/cache/actions_currencies.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hearchco/agent/src/exchange/currency"
 	"github.com/hearchco/agent/src/exchange/engines"
+	"github.com/hearchco/agent/src/utils/morestrings"
 )
 
 func (db DB) SetCurrencies(base currency.Currency, engs []engines.Name, currencies currency.Currencies, ttl ...time.Duration) error {
@@ -31,5 +32,5 @@ func combineBaseWithExchangeEnginesNames(base currency.Currency, engs []engines.
 	}
 
 	baseWithEnginesNamesStrings := append(enginesNamesStrings, base.String())
-	return combineIntoKey(baseWithEnginesNamesStrings...)
+	return morestrings.JoinNonEmpty("", "_", baseWithEnginesNamesStrings...)
 }

--- a/src/cache/actions_results.go
+++ b/src/cache/actions_results.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hearchco/agent/src/search/category"
 	"github.com/hearchco/agent/src/search/engines/options"
 	"github.com/hearchco/agent/src/search/result"
+	"github.com/hearchco/agent/src/utils/morestrings"
 )
 
 func (db DB) SetResults(q string, cat category.Name, opts options.Options, results []result.Result, ttl ...time.Duration) error {
@@ -44,7 +45,7 @@ func (db DB) GetResultsTTL(q string, cat category.Name, opts options.Options) (t
 }
 
 func combineQueryWithOptions(q string, cat category.Name, opts options.Options) string {
-	return combineIntoKey(
+	return morestrings.JoinNonEmpty("", "_",
 		q, cat.String(),
 		strconv.Itoa(opts.Pages.Start), strconv.Itoa(opts.Pages.Max),
 		opts.Locale.String(), strconv.FormatBool(opts.SafeSearch),

--- a/src/cache/actions_results.go
+++ b/src/cache/actions_results.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/hearchco/agent/src/search/category"
+	"github.com/hearchco/agent/src/search/engines/options"
+	"github.com/hearchco/agent/src/search/result"
+)
+
+func (db DB) SetResults(q string, cat category.Name, opts options.Options, results []result.Result, ttl ...time.Duration) error {
+	key := combineQueryWithOptions(q, cat, opts)
+	return db.driver.Set(key, results, ttl...)
+}
+
+func (db DB) GetResults(q string, cat category.Name, opts options.Options) ([]result.Result, error) {
+	var results []result.Result
+	var err error
+
+	key := combineQueryWithOptions(q, cat, opts)
+	if cat == category.IMAGES {
+		var imgResults []result.Images
+		err = db.driver.Get(key, &imgResults)
+		results = make([]result.Result, 0, len(imgResults))
+		for _, imgResult := range imgResults {
+			results = append(results, &imgResult)
+		}
+	} else {
+		var genResults []result.General
+		err = db.driver.Get(key, &genResults)
+		results = make([]result.Result, 0, len(genResults))
+		for _, imgResult := range genResults {
+			results = append(results, &imgResult)
+		}
+	}
+
+	return results, err
+}
+
+func (db DB) GetResultsTTL(q string, cat category.Name, opts options.Options) (time.Duration, error) {
+	key := combineQueryWithOptions(q, cat, opts)
+	return db.driver.GetTTL(key)
+}
+
+func combineQueryWithOptions(q string, cat category.Name, opts options.Options) string {
+	return combineIntoKey(
+		q, cat.String(),
+		strconv.Itoa(opts.Pages.Start), strconv.Itoa(opts.Pages.Max),
+		opts.Locale.String(), strconv.FormatBool(opts.SafeSearch),
+	)
+}

--- a/src/utils/anonymize/encrypt.go
+++ b/src/utils/anonymize/encrypt.go
@@ -1,0 +1,63 @@
+package anonymize
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+)
+
+// Encrypts the given value using the given secret.
+func Encrypt(plaintext []byte, secret string) (string, error) {
+	key := []byte(secret)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// Decrypts the given ciphertext using the given secret.
+func Decrypt(ciphertextBase64, secret string) ([]byte, error) {
+	key := []byte(secret)
+	ciphertext, err := base64.StdEncoding.DecodeString(ciphertextBase64)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, errors.New("ciphertext too short")
+	}
+
+	nonce, ciphertext := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}


### PR DESCRIPTION
Not gonna be doing this, caching results from a query is too much work for too little gain. We will focus on caching things that actually make sense to cache:
- [x] exchange rates
- [ ] images for imageproxy (not the requests themselves since they contain a changing timestamp, but the result from proxying)
- [ ] favicons