### PR TITLE
docs: add docs for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Hearchco agent repository built using Go
+
+## Installation
+
+### Docker
+[https://github.com/hearchco/agent/pkgs/container/agent](https://github.com/hearchco/agent/pkgs/container/agent)
+
+```bash
+docker pull ghcr.io/hearchco/agent
+```
+
+### Binary
+<details>
+    <summary>Binary file - Linux</summary>
+
+Download the latest release from the [releases page](https://github.com/hearchco/agent/releases) manually, or automatically like below and set the permissions for the files.
+
+```bash
+# Replace the 'match' part with your own ARCH
+curl -L -o /opt/hearchco <<< echo $(curl -sL https://api.github.com/repos/hearchco/agent/releases/latest | jq -r '.assets[] | select(.name? | match("linux_amd64$")) | .browser_download_url')
+```
+
+### Create a user and modify the rights.
+
+```bash
+sudo useradd --shell /bin/bash --system --user-group hearchco
+sudo chown hearchco:hearchco /opt/hearchco
+```
+
+## Start/Stop/Status
+
+### Create a Systemd Unit
+
+Save example systemd unit file into `/etc/systemd/system/hearchco.service` [docs](../docs/hearchco.service).
+
+### Start the hearchco Service
+
+Reload the service daemon, start the newly create service and check status.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl start hearchco
+sudo systemctl status hearchco
+```
+
+### Debug
+
+```bash
+sudo journalctl -u hearchco -b --reverse
+```
+
+### Start hearchco on Startup
+
+```bash
+sudo systemctl enable hearchco.service
+```
+
+</details>

--- a/docs/hearchco.service
+++ b/docs/hearchco.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=Agent for Hearchco Metasearch engine built using Go
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+# Find & Replace User/Group/Path with your own
+User=hearchco
+Group=hearchco
+Type=simple
+ExecStart=/opt/hearchco --verbosity --config-path="hearchco.yaml"
+WorkingDirectory=/opt/hearchco
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+# See https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+DevicePolicy=closed
+NoNewPrivileges=yes
+PrivateTmp=yes
+#PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+#ReadWritePaths=/opt/hearchco
+
+# Prevent from accessing any real (physical) devices
+PrivateDevices=yes
+
+# You can change the following line to `strict` instead of `full` if you don't
+# want it to be able to write anything on your filesystem outside of $ReadWritePaths.
+ProtectSystem=strict
+
+# You can uncomment the following line if you don't have any media in /home/*.
+# This will prevent hearchco from ever reading/writing anything there.
+ProtectHome=true


### PR DESCRIPTION
Adds a README file along with an example systemd unit file (arguments [from here](https://github.com/navidrome/website/blob/5f299635282f652b2a47713ca61f6be6024559e9/content/en/docs/Installation/linux.md?plain=1#L57)).