### PR TITLE
fix(moreurls): assert that FQDN is not empty upon creation

### DIFF
--- a/src/search/engines/bing/s_images.go
+++ b/src/search/engines/bing/s_images.go
@@ -208,7 +208,6 @@ func (se Engine) ImageSearch(query string, opts options.Options, resChan chan re
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/bing/s_web.go
+++ b/src/search/engines/bing/s_web.go
@@ -55,7 +55,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/brave/s_web.go
+++ b/src/search/engines/brave/s_web.go
@@ -46,7 +46,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/duckduckgo/s_web.go
+++ b/src/search/engines/duckduckgo/s_web.go
@@ -72,7 +72,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
-						Str("result", fmt.Sprintf("%v", r)).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/etools/s_web.go
+++ b/src/search/engines/etools/s_web.go
@@ -56,7 +56,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/google/s_web.go
+++ b/src/search/engines/google/s_web.go
@@ -32,7 +32,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/googlescholar/s_web.go
+++ b/src/search/engines/googlescholar/s_web.go
@@ -45,7 +45,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/mojeek/s_web.go
+++ b/src/search/engines/mojeek/s_web.go
@@ -32,7 +32,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/presearch/s_web.go
+++ b/src/search/engines/presearch/s_web.go
@@ -64,7 +64,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
-						Str("result", fmt.Sprintf("%v", r)).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/qwant/s_web.go
+++ b/src/search/engines/qwant/s_web.go
@@ -54,7 +54,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
-						Str("result", fmt.Sprintf("%v", r)).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/startpage/s_web.go
+++ b/src/search/engines/startpage/s_web.go
@@ -33,7 +33,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/swisscows/s_web.go
+++ b/src/search/engines/swisscows/s_web.go
@@ -73,7 +73,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 				log.Error().
 					Caller().
 					Err(err).
-					Str("result", fmt.Sprintf("%v", r)).
 					Msg("Failed to construct result")
 			} else {
 				log.Trace().

--- a/src/search/engines/yahoo/s_web.go
+++ b/src/search/engines/yahoo/s_web.go
@@ -74,7 +74,6 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
-				Str("result", fmt.Sprintf("%v", r)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/yep/s_web.go
+++ b/src/search/engines/yep/s_web.go
@@ -74,7 +74,6 @@ package yep
 // 				log.Error().
 // 					Caller().
 // 					Err(err).
-// 					Str("result", fmt.Sprintf("%v", r)).
 // 					Msg("Failed to construct result")
 // 			} else {
 // 				log.Trace().

--- a/src/search/result/construct.go
+++ b/src/search/result/construct.go
@@ -7,7 +7,23 @@ import (
 )
 
 func ConstructResult(seName engines.Name, urll string, title string, description string, page int, onPageRank int) (WebScraped, error) {
-	res := WebScraped{
+	if urll == "" {
+		return WebScraped{}, fmt.Errorf("invalid URL: empty")
+	}
+
+	if title == "" {
+		return WebScraped{}, fmt.Errorf("invalid title: empty")
+	}
+
+	if page <= 0 {
+		return WebScraped{}, fmt.Errorf("invalid page: %d", page)
+	}
+
+	if onPageRank <= 0 {
+		return WebScraped{}, fmt.Errorf("invalid onPageRank: %d", onPageRank)
+	}
+
+	return WebScraped{
 		url:         urll,
 		title:       title,
 		description: description,
@@ -19,25 +35,7 @@ func ConstructResult(seName engines.Name, urll string, title string, description
 			page,
 			onPageRank,
 		},
-	}
-
-	if urll == "" {
-		return res, fmt.Errorf("invalid URL: empty")
-	}
-
-	if title == "" {
-		return res, fmt.Errorf("invalid title: empty")
-	}
-
-	if page <= 0 {
-		return res, fmt.Errorf("invalid page: %d", page)
-	}
-
-	if onPageRank <= 0 {
-		return res, fmt.Errorf("invalid onPageRank: %d", onPageRank)
-	}
-
-	return res, nil
+	}, nil
 }
 
 func ConstructImagesResult(
@@ -46,7 +44,35 @@ func ConstructImagesResult(
 	thumbnailUrl string, sourceName string, sourceUrl string,
 ) (ImagesScraped, error) {
 	res, err := ConstructResult(seName, urll, title, description, page, onPageRank)
-	imgres := ImagesScraped{
+	if err != nil {
+		return ImagesScraped{}, err
+	}
+
+	if originalHeight <= 0 {
+		return ImagesScraped{}, fmt.Errorf("invalid originalHeight: %d", originalHeight)
+	}
+
+	if originalWidth <= 0 {
+		return ImagesScraped{}, fmt.Errorf("invalid originalWidth: %d", originalWidth)
+	}
+
+	if thumbnailHeight <= 0 {
+		return ImagesScraped{}, fmt.Errorf("invalid thumbnailHeight: %d", thumbnailHeight)
+	}
+
+	if thumbnailWidth <= 0 {
+		return ImagesScraped{}, fmt.Errorf("invalid thumbnailWidth: %d", thumbnailWidth)
+	}
+
+	if thumbnailUrl == "" {
+		return ImagesScraped{}, fmt.Errorf("invalid thumbnailUrl: empty")
+	}
+
+	if sourceUrl == "" {
+		return ImagesScraped{}, fmt.Errorf("invalid sourceUrl: empty")
+	}
+
+	return ImagesScraped{
 		WebScraped: res,
 
 		originalSize: scrapedImageFormat{
@@ -60,34 +86,5 @@ func ConstructImagesResult(
 		thumbnailURL: thumbnailUrl,
 		sourceName:   sourceName,
 		sourceURL:    sourceUrl,
-	}
-	if err != nil {
-		return imgres, err
-	}
-
-	if originalHeight <= 0 {
-		return imgres, fmt.Errorf("invalid originalHeight: %d", originalHeight)
-	}
-
-	if originalWidth <= 0 {
-		return imgres, fmt.Errorf("invalid originalWidth: %d", originalWidth)
-	}
-
-	if thumbnailHeight <= 0 {
-		return imgres, fmt.Errorf("invalid thumbnailHeight: %d", thumbnailHeight)
-	}
-
-	if thumbnailWidth <= 0 {
-		return imgres, fmt.Errorf("invalid thumbnailWidth: %d", thumbnailWidth)
-	}
-
-	if thumbnailUrl == "" {
-		return imgres, fmt.Errorf("invalid thumbnailUrl: empty")
-	}
-
-	if sourceUrl == "" {
-		return imgres, fmt.Errorf("invalid sourceUrl: empty")
-	}
-
-	return imgres, nil
+	}, nil
 }

--- a/src/utils/moreurls/fqdn.go
+++ b/src/utils/moreurls/fqdn.go
@@ -19,12 +19,13 @@ func FQDN(urll string) string {
 	}
 
 	// Check if the hostname is empty.
-	if u.Hostname() == "" {
+	h := u.Hostname()
+	if h == "" {
 		log.Panic().
 			Str("url", urll).
 			Msg("Hostname is empty")
 		// ^PANIC - Assert non-empty URL.
 	}
 
-	return u.Hostname()
+	return h
 }

--- a/src/utils/moreurls/fqdn.go
+++ b/src/utils/moreurls/fqdn.go
@@ -18,5 +18,13 @@ func FQDN(urll string) string {
 		// ^PANIC - Assert correct URL.
 	}
 
+	// Check if the hostname is empty.
+	if u.Hostname() == "" {
+		log.Panic().
+			Str("url", urll).
+			Msg("Hostname is empty")
+		// ^PANIC - Assert non-empty URL.
+	}
+
 	return u.Hostname()
 }

--- a/src/utils/moreurls/fqdn.go
+++ b/src/utils/moreurls/fqdn.go
@@ -8,6 +8,13 @@ import (
 
 // Returns the fully qualified domain name of the URL.
 func FQDN(urll string) string {
+	// Check if the url is empty.
+	if urll == "" {
+		log.Panic().
+			Str("url", urll).
+			Msg("URL is empty")
+	}
+
 	// Parse the URL.
 	u, err := url.Parse(urll)
 	if err != nil {


### PR DESCRIPTION
I found in logs that there were panics due to an assert in result.FQDN() that demands FQDN isn't empty. I've added this here earlier since it also makes sense to happen here but now we can actually see which URLs are causing the problems and fix that.