### PR TITLE
fix(result): construct result check for proper url

### DIFF
--- a/src/search/engines/bing/s_images.go
+++ b/src/search/engines/bing/s_images.go
@@ -208,6 +208,11 @@ func (se Engine) ImageSearch(query string, opts options.Options, resChan chan re
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", jsonMetadata.ImageURL).
+				Str("title", titleText).
+				Str("desc", jsonMetadata.Desc).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/bing/s_web.go
+++ b/src/search/engines/bing/s_web.go
@@ -55,6 +55,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/brave/s_web.go
+++ b/src/search/engines/brave/s_web.go
@@ -46,6 +46,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/duckduckgo/s_web.go
+++ b/src/search/engines/duckduckgo/s_web.go
@@ -72,6 +72,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
+						Str("url", urlText).
+						Str("title", titleText).
+						Str("desc", descText).
+						Int("page", page).
+						Int("rank", onPageRank).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/etools/s_web.go
+++ b/src/search/engines/etools/s_web.go
@@ -56,6 +56,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/google/s_images.go
+++ b/src/search/engines/google/s_images.go
@@ -70,7 +70,11 @@ func (se Engine) ImageSearch(query string, opts options.Options, resChan chan re
 					log.Error().
 						Caller().
 						Err(err).
-						Str("result", fmt.Sprintf("%v", r)).
+						Str("url", origImg.Url).
+						Str("title", resultJson.PageTitle).
+						Str("desc", textInGridJson.Snippet).
+						Int("page", page).
+						Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/google/s_web.go
+++ b/src/search/engines/google/s_web.go
@@ -32,6 +32,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/googlescholar/s_web.go
+++ b/src/search/engines/googlescholar/s_web.go
@@ -45,6 +45,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/mojeek/s_web.go
+++ b/src/search/engines/mojeek/s_web.go
@@ -32,6 +32,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/presearch/s_web.go
+++ b/src/search/engines/presearch/s_web.go
@@ -64,6 +64,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
+						Str("url", goodURL).
+						Str("title", goodTitle).
+						Str("desc", goodDesc).
+						Int("page", page).
+						Int("rank", counter).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/qwant/s_web.go
+++ b/src/search/engines/qwant/s_web.go
@@ -54,6 +54,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 					log.Error().
 						Caller().
 						Err(err).
+						Str("url", goodURL).
+						Str("title", goodTitle).
+						Str("desc", goodDesc).
+						Int("page", page).
+						Int("rank", counter).
 						Msg("Failed to construct result")
 				} else {
 					log.Trace().

--- a/src/search/engines/startpage/s_web.go
+++ b/src/search/engines/startpage/s_web.go
@@ -33,6 +33,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/swisscows/s_web.go
+++ b/src/search/engines/swisscows/s_web.go
@@ -73,6 +73,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 				log.Error().
 					Caller().
 					Err(err).
+					Str("url", goodURL).
+					Str("title", goodTitle).
+					Str("desc", goodDesc).
+					Int("page", page).
+					Int("rank", counter).
 					Msg("Failed to construct result")
 			} else {
 				log.Trace().

--- a/src/search/engines/yahoo/s_web.go
+++ b/src/search/engines/yahoo/s_web.go
@@ -74,6 +74,11 @@ func (se Engine) WebSearch(query string, opts options.Options, resChan chan resu
 			log.Error().
 				Caller().
 				Err(err).
+				Str("url", urlText).
+				Str("title", titleText).
+				Str("desc", descText).
+				Int("page", page).
+				Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 				Msg("Failed to construct result")
 		} else {
 			log.Trace().

--- a/src/search/engines/yep/s_web.go
+++ b/src/search/engines/yep/s_web.go
@@ -74,6 +74,11 @@ package yep
 // 				log.Error().
 // 					Caller().
 // 					Err(err).
+// 					Str("url", goodURL).
+// 					Str("title", goodTitle).
+// 					Str("desc", goodDesc).
+// 					Int("page", page).
+// 					Int("rank", pageRankCounter.GetPlusOne(pageIndex)).
 // 					Msg("Failed to construct result")
 // 			} else {
 // 				log.Trace().

--- a/src/search/result/construct.go
+++ b/src/search/result/construct.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/hearchco/agent/src/search/engines"
 )
@@ -9,6 +10,15 @@ import (
 func ConstructResult(seName engines.Name, urll string, title string, description string, page int, onPageRank int) (WebScraped, error) {
 	if urll == "" {
 		return WebScraped{}, fmt.Errorf("invalid URL: empty")
+	}
+
+	u, err := url.Parse(urll)
+	if err != nil {
+		return WebScraped{}, fmt.Errorf("invalid URL: %s", err)
+	}
+
+	if u.Hostname() == "" {
+		return WebScraped{}, fmt.Errorf("invalid URL: no hostname")
 	}
 
 	if title == "" {
@@ -24,7 +34,7 @@ func ConstructResult(seName engines.Name, urll string, title string, description
 	}
 
 	return WebScraped{
-		url:         urll,
+		url:         u.String(),
 		title:       title,
 		description: description,
 		rank: RankScraped{


### PR DESCRIPTION
This fixes a random first rank result returned by Google on query `psychosis` that doesn't have hostname set for some reason (relative URL to google itself? I couldn't find this exact result on Google tho).

Also added this nice log so we can see when this happens:

```
Nov 21 19:07:23 ERR github.com/hearchco/agent/src/search/engines/google/s_web.go:40 > Failed to construct result error="invalid URL: no hostname" desc="What is psychosis? Psychosis refers to a collection of symptoms that affect the mind, where there has been some loss of contact with reality. During an episode of psychosis, a person's thoughts and perceptions are disrupted and they may have difficulty recognizing what is real and what is not.Understanding Psychosis - National Institute of Mental HealthNational Institute of Mental Health (NIMH) (.gov)https://www.nimh.nih.gov › health › publications › unde...National Institute of Mental Health (NIMH) (.gov)National Institute of Mental Health (NIMH) (.gov)About featured snippets•FeedbackFeedback" page=1 rank=1 title="Understanding Psychosis - National Institute of Mental Health" url=/search?lr=lang_en&safe=off&sca_esv=41abccaec8fca31d&hl=en&tbs=lr:lang_1en&q=psychosis&udm=2&source=univ&fir=QxNkX0jFieDnaM%252C1XBXBdMLUacB2M%252C_%253BJLKqnJ1RLMM-vM%252Cv76sigNh6qL79M%252C_%253B_CkWLoPL5jyO8M%252C1XBXBdMLUacB2M%252C_%253BEue8QFmeG83t9M%252C1XBXBdMLUacB2M%252C_%253Be-FVvrsHlzsDYM%252Ci0Oly0Qzci0ZlM%252C_&usg=AI4_-kTuvAdJMSLpQSH8lnJeSzUDJuYG_g&sa=X&ved=2ahUKEwin0Ouagu6JAxVb9wIHHQuCDosQ420oAHoECDkQBQ
```